### PR TITLE
Show Build Status Reason and Message

### DIFF
--- a/pkg/commands/build/status_test.go
+++ b/pkg/commands/build/status_test.go
@@ -5,10 +5,16 @@ package build_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
 	"github.com/sclevine/spec"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/pivotal/build-service-cli/pkg/commands/build"
 	"github.com/pivotal/build-service-cli/pkg/testhelpers"
@@ -22,9 +28,11 @@ func testBuildStatusCommand(t *testing.T, when spec.G, it spec.S) {
 	const (
 		image                       = "test-image"
 		defaultNamespace            = "some-default-namespace"
-		expectedOutputForMostRecent = `Image:      repo.com/image-3:tag
-Status:     BUILDING
-Reasons:    TRIGGER
+		expectedOutputForMostRecent = `Image:            repo.com/image-3:tag
+Status:           BUILDING
+Build Reasons:    TRIGGER
+
+Pod Name:    pod-three
 
 Builder:      some-repo.com/my-builder
 Run Image:    some-repo.com/run-image
@@ -36,9 +44,11 @@ bp-id-1         bp-version-1
 bp-id-2         bp-version-2
 
 `
-		expectedOutputForBuildNumber = `Image:      repo.com/image-1:tag
-Status:     SUCCESS
-Reasons:    CONFIG
+		expectedOutputForBuildNumber = `Image:            repo.com/image-1:tag
+Status:           SUCCESS
+Build Reasons:    CONFIG
+
+Pod Name:    pod-one
 
 Builder:      some-repo.com/my-builder
 Run Image:    some-repo.com/run-image
@@ -151,6 +161,80 @@ bp-id-2         bp-version-2
 						}.TestKpack(t, cmdFunc)
 					})
 				})
+			})
+		})
+
+		when("build status returns a reason and message", func() {
+			it("displays status reason and status message", func() {
+				expectedOutput := `Image:             repo.com/image-3:tag
+Status:            BUILDING
+Build Reasons:     TRIGGER
+Status Reason:     some-reason
+Status Message:    some-message
+
+Pod Name:    some-pod
+
+Builder:      some-repo.com/my-builder
+Run Image:    some-repo.com/run-image
+
+Source:    Local Source
+
+BUILDPACK ID    BUILDPACK VERSION
+bp-id-1         bp-version-1
+bp-id-2         bp-version-2
+
+`
+				bld := &v1alpha1.Build{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "bld-three",
+						Namespace:         "some-default-namespace",
+						CreationTimestamp: metav1.Time{Time: time.Time{}.Add(5 * time.Hour)},
+						Labels: map[string]string{
+							v1alpha1.ImageLabel:       image,
+							v1alpha1.BuildNumberLabel: "3",
+						},
+						Annotations: map[string]string{
+							v1alpha1.BuildReasonAnnotation: "TRIGGER",
+						},
+					},
+					Spec: v1alpha1.BuildSpec{
+						Builder: v1alpha1.BuildBuilderSpec{
+							Image: "some-repo.com/my-builder",
+						},
+					},
+					Status: v1alpha1.BuildStatus{
+						Status: corev1alpha1.Status{
+							Conditions: corev1alpha1.Conditions{
+								{
+									Type:    corev1alpha1.ConditionSucceeded,
+									Status:  corev1.ConditionUnknown,
+									Reason:  "some-reason",
+									Message: "some-message",
+								},
+							},
+						},
+						BuildMetadata: v1alpha1.BuildpackMetadataList{
+							{
+								Id:      "bp-id-1",
+								Version: "bp-version-1",
+							},
+							{
+								Id:      "bp-id-2",
+								Version: "bp-version-2",
+							},
+						},
+						Stack: v1alpha1.BuildStack{
+							RunImage: "some-repo.com/run-image",
+						},
+						LatestImage: "repo.com/image-3:tag",
+						PodName: "some-pod",
+					},
+				}
+				testhelpers.CommandTest{
+					Objects:        []runtime.Object{bld},
+					Args:           []string{image},
+					ExpectedOutput: expectedOutput,
+				}.TestKpack(t, cmdFunc)
 			})
 		})
 	})

--- a/pkg/testhelpers/build.go
+++ b/pkg/testhelpers/build.go
@@ -57,6 +57,7 @@ func MakeTestBuilds(image string, namespace string) []runtime.Object {
 				RunImage: "some-repo.com/run-image",
 			},
 			LatestImage: "repo.com/image-1:tag",
+			PodName: "pod-one",
 		},
 	}
 	buildTwo := &v1alpha1.Build{
@@ -85,6 +86,7 @@ func MakeTestBuilds(image string, namespace string) []runtime.Object {
 				},
 			},
 			LatestImage: "repo.com/image-2:tag",
+			PodName: "pod-two",
 		},
 	}
 	buildThree := &v1alpha1.Build{
@@ -128,6 +130,7 @@ func MakeTestBuilds(image string, namespace string) []runtime.Object {
 				RunImage: "some-repo.com/run-image",
 			},
 			LatestImage: "repo.com/image-3:tag",
+			PodName: "pod-three",
 		},
 	}
 	ignoredBuild := &v1alpha1.Build{


### PR DESCRIPTION
Some changes to take note of:
- Add Status Reason and Status Message when they are set on the Build's Status
- Rename Reason to Build Reason
- Show Pod Name
- Do not show current container as I felt like it was not as useful.

Before:
<img width="1609" alt="Screen Shot 2020-08-04 at 4 40 46 PM" src="https://user-images.githubusercontent.com/7309317/89342776-44ac1c00-d671-11ea-8186-8142800bab71.png">

After with Build Status Reason + Message:
<img width="1711" alt="Screen Shot 2020-08-04 at 4 37 46 PM" src="https://user-images.githubusercontent.com/7309317/89342804-4f66b100-d671-11ea-9b33-1d442fb29b25.png">

After with no Build Status Reason + Message:
<img width="1600" alt="Screen Shot 2020-08-04 at 4 39 05 PM" src="https://user-images.githubusercontent.com/7309317/89342827-58578280-d671-11ea-8990-93878baa4881.png">
