### PR TITLE
Accept new kp.kpack.io/v1alpha2 version of import descriptor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
-	k8s.io/api v0.17.5
-	k8s.io/apimachinery v0.17.5
+	k8s.io/api v0.17.6
+	k8s.io/apimachinery v0.17.6
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1603,6 +1603,8 @@ k8s.io/api v0.17.3/go.mod h1:YZ0OTkuw7ipbe305fMpIdf3GLXZKRigjtZaV5gzC2J0=
 k8s.io/api v0.17.4/go.mod h1:5qxx6vjmwUVG2nHQTKGlLts8Tbok8PzHl4vHtVFuZCA=
 k8s.io/api v0.17.5 h1:EkVieIbn1sC8YCDwckLKLpf+LoVofXYW72+LTZWo4aQ=
 k8s.io/api v0.17.5/go.mod h1:0zV5/ungglgy2Rlm3QK8fbxkXVs+BSJWpJP/+8gUVLY=
+k8s.io/api v0.17.6 h1:S6qZSkjdOU0N/TYBZKoR1o7YVSiWMGFU0XXDoqs2ioA=
+k8s.io/api v0.17.6/go.mod h1:1jKVwkj0UZ4huak/yRt3MFfU5wc32+B41SkNN5HhyFg=
 k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604/go.mod h1:7H8sjDlWQu89yWB3FhZfsLyRCRLuoXoCoY5qtwW1q6I=
 k8s.io/apiextensions-apiserver v0.16.4/go.mod h1:HYQwjujEkXmQNhap2C9YDdIVOSskGZ3et0Mvjcyjbto=
 k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdBCfsWMDWAmSTs=
@@ -1621,6 +1623,8 @@ k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apimachinery v0.17.5 h1:QAjfgeTtSGksdkgyaPrIb4lhU16FWMIzxKejYD5S0gc=
 k8s.io/apimachinery v0.17.5/go.mod h1:ioIo1G/a+uONV7Tv+ZmCbMG1/a3kVw5YcDdncd8ugQ0=
+k8s.io/apimachinery v0.17.6 h1:P0MNfucrmKLPsOSRbhDuG0Tplrpg7hVY4fJHh5sUIUw=
+k8s.io/apimachinery v0.17.6/go.mod h1:Lg8zZ5iC/O8UjCqW6DNhcQG2m4TdjF9kwG3891OWbbA=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/apiserver v0.16.4/go.mod h1:kbLJOak655g6W7C+muqu1F76u9wnEycfKMqbVaXIdAc=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
@@ -1672,6 +1676,8 @@ k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C
 k8s.io/kube-openapi v0.0.0-20200316234421-82d701f24f9d/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 h1:NeQXVJ2XFSkRoPzRo8AId01ZER+j8oV4SZADT4iBOXQ=
+k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
 k8s.io/kubectl v0.17.2/go.mod h1:y4rfLV0n6aPmvbRCqZQjvOp3ezxsFgpqL+zF5jH/lxk=
 k8s.io/kubernetes v1.11.10/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/pkg/commands/import/testdata/invalid-deps.yaml
+++ b/pkg/commands/import/testdata/invalid-deps.yaml
@@ -1,0 +1,1 @@
+apiVersion: invalid

--- a/pkg/commands/import/testdata/updated-deps.yaml
+++ b/pkg/commands/import/testdata/updated-deps.yaml
@@ -1,21 +1,21 @@
-apiVersion: kp.kpack.io/v1alpha1
+apiVersion: kp.kpack.io/v1alpha2
 kind: DependencyDescriptor
-defaultClusterBuilder: some-ccb
-defaultStack: some-stack
-stores:
-- name: some-store
-  sources:
-  - image: some-registry.io/some-project/store-image-2
-stacks:
-- name: some-stack
-  buildImage:
-    image: some-registry.io/some-project/build-image-2
-  runImage:
-    image: some-registry.io/some-project/run-image-2
+defaultClusterBuilder: some-cb
+defaultClusterStack: some-stack
+clusterStores:
+  - name: some-store
+    sources:
+      - image: some-registry.io/some-project/store-image-2
+clusterStacks:
+  - name: some-stack
+    buildImage:
+      image: some-registry.io/some-project/build-image-2
+    runImage:
+      image: some-registry.io/some-project/run-image-2
 clusterBuilders:
-- name: some-ccb
-  stack: some-stack
-  store: some-store
-  order:
-  - group:
-    - id: buildpack-2
+  - name: some-cb
+    clusterStack: some-stack
+    clusterStore: some-store
+    order:
+      - group:
+          - id: buildpack-2

--- a/pkg/commands/import/testdata/v1-deps.yaml
+++ b/pkg/commands/import/testdata/v1-deps.yaml
@@ -1,12 +1,12 @@
-apiVersion: kp.kpack.io/v1alpha2
+apiVersion: kp.kpack.io/v1alpha1
 kind: DependencyDescriptor
 defaultClusterBuilder: some-cb
-defaultClusterStack: some-stack
-clusterStores:
+defaultStack: some-stack
+stores:
 - name: some-store
   sources:
   - image: some-registry.io/some-project/store-image
-clusterStacks:
+stacks:
 - name: some-stack
   buildImage:
     image: some-registry.io/some-project/build-image
@@ -14,8 +14,8 @@ clusterStacks:
     image: some-registry.io/some-project/run-image
 clusterBuilders:
 - name: some-cb
-  clusterStack: some-stack
-  clusterStore: some-store
+  stack: some-stack
+  store: some-store
   order:
   - group:
     - id: buildpack-1

--- a/pkg/import/dependency_descriptor_test.go
+++ b/pkg/import/dependency_descriptor_test.go
@@ -10,122 +10,124 @@ import (
 	importpkg "github.com/pivotal/build-service-cli/pkg/import"
 )
 
-func TestDescriptorValidate(t *testing.T) {
-	spec.Run(t, "TestDescriptorValidate", testDescriptorValidate)
+func TestDescriptor(t *testing.T) {
+	spec.Run(t, "TestDescriptor", testDescriptor)
 }
 
-func testDescriptorValidate(t *testing.T, when spec.G, it spec.S) {
-	desc := importpkg.DependencyDescriptor{
-		DefaultStack:          "some-stack",
-		DefaultClusterBuilder: "some-ccb",
-		Stores: []importpkg.Store{
-			{
-				Name: "some-store",
-				Sources: []importpkg.Source{
-					{
-						Image: "some-store-image",
+func testDescriptor(t *testing.T, when spec.G, it spec.S) {
+	when("#Validate", func() {
+		desc := importpkg.DependencyDescriptor{
+			DefaultClusterStack:   "some-stack",
+			DefaultClusterBuilder: "some-ccb",
+			ClusterStores: []importpkg.ClusterStore{
+				{
+					Name: "some-store",
+					Sources: []importpkg.Source{
+						{
+							Image: "some-store-image",
+						},
 					},
 				},
 			},
-		},
-		Stacks: []importpkg.Stack{
-			{
-				Name: "some-stack",
-				BuildImage: importpkg.Source{
-					Image: "build-image",
-				},
-				RunImage: importpkg.Source{
-					Image: "run-image",
+			ClusterStacks: []importpkg.ClusterStack{
+				{
+					Name: "some-stack",
+					BuildImage: importpkg.Source{
+						Image: "build-image",
+					},
+					RunImage: importpkg.Source{
+						Image: "run-image",
+					},
 				},
 			},
-		},
-		ClusterBuilders: []importpkg.ClusterBuilder{
-			{
-				Name:  "some-ccb",
-				Stack: "some-stack",
-				Store: "some-store",
-				Order: []v1alpha1.OrderEntry{
-					{
-						Group: []v1alpha1.BuildpackRef{
-							{
-								BuildpackInfo: v1alpha1.BuildpackInfo{
-									Id:      "some-buildpack",
-									Version: "1.2.3",
+			ClusterBuilders: []importpkg.ClusterBuilder{
+				{
+					Name:         "some-ccb",
+					ClusterStack: "some-stack",
+					ClusterStore: "some-store",
+					Order: []v1alpha1.OrderEntry{
+						{
+							Group: []v1alpha1.BuildpackRef{
+								{
+									BuildpackInfo: v1alpha1.BuildpackInfo{
+										Id:      "some-buildpack",
+										Version: "1.2.3",
+									},
+									Optional: false,
 								},
-								Optional: false,
 							},
 						},
 					},
 				},
 			},
-		},
-	}
+		}
 
-	it("validates successfully", func() {
-		require.NoError(t, desc.Validate())
-	})
-
-	when("there is a duplicate store name", func() {
-		desc.Stores = append(desc.Stores, importpkg.Store{
-			Name: "some-store",
+		it("validates successfully", func() {
+			require.NoError(t, desc.Validate())
 		})
 
-		it("fails validation", func() {
-			require.Error(t, desc.Validate())
-		})
-	})
+		when("there is a duplicate store name", func() {
+			desc.ClusterStores = append(desc.ClusterStores, importpkg.ClusterStore{
+				Name: "some-store",
+			})
 
-	when("there is a duplicate stack name", func() {
-		desc.Stacks = append(desc.Stacks, importpkg.Stack{
-			Name: "some-stack",
-		})
-
-		it("fails validation", func() {
-			require.Error(t, desc.Validate())
-		})
-	})
-
-	when("there is a duplicate ccb name", func() {
-		desc.ClusterBuilders = append(desc.ClusterBuilders, importpkg.ClusterBuilder{
-			Name:  "some-ccb",
-			Stack: "some-stack",
-			Store: "some-store",
+			it("fails validation", func() {
+				require.Error(t, desc.Validate())
+			})
 		})
 
-		it("fails validation", func() {
-			require.Error(t, desc.Validate())
+		when("there is a duplicate stack name", func() {
+			desc.ClusterStacks = append(desc.ClusterStacks, importpkg.ClusterStack{
+				Name: "some-stack",
+			})
+
+			it("fails validation", func() {
+				require.Error(t, desc.Validate())
+			})
 		})
-	})
 
-	when("the default stack does not exist", func() {
-		desc.DefaultStack = "does-not-exist"
+		when("there is a duplicate ccb name", func() {
+			desc.ClusterBuilders = append(desc.ClusterBuilders, importpkg.ClusterBuilder{
+				Name:         "some-ccb",
+				ClusterStack: "some-stack",
+				ClusterStore: "some-store",
+			})
 
-		it("fails validation", func() {
-			require.Error(t, desc.Validate())
+			it("fails validation", func() {
+				require.Error(t, desc.Validate())
+			})
 		})
-	})
 
-	when("the default ccb does not exist", func() {
-		desc.DefaultStack = "does-not-exist"
+		when("the default stack does not exist", func() {
+			desc.DefaultClusterStack = "does-not-exist"
 
-		it("fails validation", func() {
-			require.Error(t, desc.Validate())
+			it("fails validation", func() {
+				require.Error(t, desc.Validate())
+			})
 		})
-	})
 
-	when("the ccb uses a stack that does not exist", func() {
-		desc.ClusterBuilders[0].Stack = "does-not-exist"
+		when("the default ccb does not exist", func() {
+			desc.DefaultClusterStack = "does-not-exist"
 
-		it("fails validation", func() {
-			require.Error(t, desc.Validate())
+			it("fails validation", func() {
+				require.Error(t, desc.Validate())
+			})
 		})
-	})
 
-	when("the ccb uses a store that does not exist", func() {
-		desc.ClusterBuilders[0].Store = "does-not-exist"
+		when("the ccb uses a stack that does not exist", func() {
+			desc.ClusterBuilders[0].ClusterStack = "does-not-exist"
 
-		it("fails validation", func() {
-			require.Error(t, desc.Validate())
+			it("fails validation", func() {
+				require.Error(t, desc.Validate())
+			})
+		})
+
+		when("the ccb uses a store that does not exist", func() {
+			desc.ClusterBuilders[0].ClusterStore = "does-not-exist"
+
+			it("fails validation", func() {
+				require.Error(t, desc.Validate())
+			})
 		})
 	})
 }

--- a/pkg/import/dependency_descriptor_v1.go
+++ b/pkg/import/dependency_descriptor_v1.go
@@ -1,0 +1,46 @@
+// Copyright 2020-Present VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package _import
+
+import (
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+)
+
+const APIVersionV1 = "kp.kpack.io/v1alpha1"
+
+type DependencyDescriptorV1 struct {
+	APIVersion            string             `yaml:"apiVersion"`
+	Kind                  string             `yaml:"kind"`
+	DefaultStack          string             `yaml:"defaultStack"`
+	DefaultClusterBuilder string             `yaml:"defaultClusterBuilder"`
+	Stores                []ClusterStore     `yaml:"stores"`
+	Stacks                []ClusterStack     `yaml:"stacks"`
+	ClusterBuilders       []ClusterBuilderV1 `yaml:"clusterBuilders"`
+}
+
+type ClusterBuilderV1 struct {
+	Name  string                `yaml:"name"`
+	Stack string                `yaml:"stack"`
+	Store string                `yaml:"store"`
+	Order []v1alpha1.OrderEntry `yaml:"order"`
+}
+
+func (d1 DependencyDescriptorV1) ToNextVersion() DependencyDescriptor {
+	var d DependencyDescriptor
+	d.APIVersion = d1.APIVersion
+	d.Kind = d1.Kind
+	d.DefaultClusterStack = d1.DefaultStack
+	d.DefaultClusterBuilder = d1.DefaultClusterBuilder
+	d.ClusterStores = d1.Stores
+	d.ClusterStacks = d1.Stacks
+	for _, cb := range d1.ClusterBuilders {
+		d.ClusterBuilders = append(d.ClusterBuilders, ClusterBuilder{
+			Name:         cb.Name,
+			ClusterStack: cb.Stack,
+			ClusterStore: cb.Store,
+			Order:        cb.Order,
+		})
+	}
+	return d
+}

--- a/pkg/import/dependency_descriptor_v1_test.go
+++ b/pkg/import/dependency_descriptor_v1_test.go
@@ -1,0 +1,70 @@
+package _import_test
+
+import (
+	"testing"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+
+	importpkg "github.com/pivotal/build-service-cli/pkg/import"
+)
+
+func TestDescriptorV1(t *testing.T) {
+	spec.Run(t, "TestDescriptorV1", testDescriptorV1)
+}
+
+func testDescriptorV1(t *testing.T, when spec.G, it spec.S) {
+	when("#ToNextVersion", func() {
+		descV1 := importpkg.DependencyDescriptorV1{
+			DefaultStack:          "some-stack",
+			DefaultClusterBuilder: "some-ccb",
+			Stores: []importpkg.ClusterStore{
+				{
+					Name: "some-store",
+					Sources: []importpkg.Source{
+						{
+							Image: "some-store-image",
+						},
+					},
+				},
+			},
+			Stacks: []importpkg.ClusterStack{
+				{
+					Name: "some-stack",
+					BuildImage: importpkg.Source{
+						Image: "build-image",
+					},
+					RunImage: importpkg.Source{
+						Image: "run-image",
+					},
+				},
+			},
+			ClusterBuilders: []importpkg.ClusterBuilderV1{
+				{
+					Name:  "some-ccb",
+					Stack: "some-stack",
+					Store: "some-store",
+					Order: []v1alpha1.OrderEntry{
+						{
+							Group: []v1alpha1.BuildpackRef{
+								{
+									BuildpackInfo: v1alpha1.BuildpackInfo{
+										Id:      "some-buildpack",
+										Version: "1.2.3",
+									},
+									Optional: false,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		it("converts successfully", func() {
+			d := descV1.ToNextVersion()
+			require.NoError(t, d.Validate())
+		})
+	})
+}

--- a/pkg/import/testdata/v1-deps.yaml
+++ b/pkg/import/testdata/v1-deps.yaml
@@ -1,12 +1,12 @@
-apiVersion: kp.kpack.io/v1alpha2
+apiVersion: kp.kpack.io/v1alpha1
 kind: DependencyDescriptor
 defaultClusterBuilder: some-cb
-defaultClusterStack: some-stack
-clusterStores:
+defaultStack: some-stack
+stores:
 - name: some-store
   sources:
   - image: some-registry.io/some-project/store-image
-clusterStacks:
+stacks:
 - name: some-stack
   buildImage:
     image: some-registry.io/some-project/build-image
@@ -14,8 +14,8 @@ clusterStacks:
     image: some-registry.io/some-project/run-image
 clusterBuilders:
 - name: some-cb
-  clusterStack: some-stack
-  clusterStore: some-store
+  stack: some-stack
+  store: some-store
   order:
   - group:
-    - id: buildpack-1
+    - id: buildpack

--- a/pkg/import/testdata/v2-deps.yaml
+++ b/pkg/import/testdata/v2-deps.yaml
@@ -18,4 +18,4 @@ clusterBuilders:
   clusterStore: some-store
   order:
   - group:
-    - id: buildpack-1
+    - id: buildpack


### PR DESCRIPTION
- Still support kp.kpack.io/v1alpha1 version
- Uses more correct key names