### PR TITLE
Reason wording

### DIFF
--- a/pkg/commands/build/status.go
+++ b/pkg/commands/build/status.go
@@ -96,7 +96,7 @@ func displayBuildStatus(cmd *cobra.Command, bld v1alpha1.Build) error {
 	statusItems := []string{
 		"Image", bld.Status.LatestImage,
 		"Status", getStatus(bld),
-		"Build Reasons", bld.Annotations[v1alpha1.BuildReasonAnnotation],
+		"Build Reason", bld.Annotations[v1alpha1.BuildReasonAnnotation],
 	}
 
 	if cond := bld.Status.GetCondition(corev1alpha1.ConditionSucceeded); cond.Reason != "" {

--- a/pkg/commands/build/status_test.go
+++ b/pkg/commands/build/status_test.go
@@ -28,9 +28,9 @@ func testBuildStatusCommand(t *testing.T, when spec.G, it spec.S) {
 	const (
 		image                       = "test-image"
 		defaultNamespace            = "some-default-namespace"
-		expectedOutputForMostRecent = `Image:            repo.com/image-3:tag
-Status:           BUILDING
-Build Reasons:    TRIGGER
+		expectedOutputForMostRecent = `Image:           repo.com/image-3:tag
+Status:          BUILDING
+Build Reason:    TRIGGER
 
 Pod Name:    pod-three
 
@@ -44,9 +44,9 @@ bp-id-1         bp-version-1
 bp-id-2         bp-version-2
 
 `
-		expectedOutputForBuildNumber = `Image:            repo.com/image-1:tag
-Status:           SUCCESS
-Build Reasons:    CONFIG
+		expectedOutputForBuildNumber = `Image:           repo.com/image-1:tag
+Status:          SUCCESS
+Build Reason:    CONFIG
 
 Pod Name:    pod-one
 
@@ -168,7 +168,7 @@ bp-id-2         bp-version-2
 			it("displays status reason and status message", func() {
 				expectedOutput := `Image:             repo.com/image-3:tag
 Status:            BUILDING
-Build Reasons:     TRIGGER
+Build Reason:      TRIGGER
 Status Reason:     some-reason
 Status Message:    some-message
 

--- a/pkg/commands/image/status.go
+++ b/pkg/commands/image/status.go
@@ -79,7 +79,7 @@ func displayImageStatus(cmd *cobra.Command, image *v1alpha1.Image, builds []v1al
 	err = statusWriter.AddBlock(
 		"Last Successful Build",
 		"Id", getId(successfulBuild),
-		"Reason", getReason(successfulBuild),
+		"Build Reason", getReason(successfulBuild),
 	)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func displayImageStatus(cmd *cobra.Command, image *v1alpha1.Image, builds []v1al
 	err = statusWriter.AddBlock(
 		"Last Failed Build",
 		"Id", getId(failedBuild),
-		"Reason", getReason(failedBuild),
+		"Build Reason", getReason(failedBuild),
 	)
 	if err != nil {
 		return err

--- a/pkg/commands/image/status_test.go
+++ b/pkg/commands/image/status_test.go
@@ -64,12 +64,12 @@ Message:        --
 LatestImage:    test-registry.io/test-image-1@sha256:abcdef123
 
 Last Successful Build
-Id:        1
-Reason:    CONFIG
+Id:              1
+Build Reason:    CONFIG
 
 Last Failed Build
-Id:        2
-Reason:    COMMIT,BUILDPACK
+Id:              2
+Build Reason:    COMMIT,BUILDPACK
 
 `
 
@@ -119,12 +119,12 @@ Message:        --
 LatestImage:    test-registry.io/test-image-1@sha256:abcdef123
 
 Last Successful Build
-Id:        1
-Reason:    CONFIG
+Id:              1
+Build Reason:    CONFIG
 
 Last Failed Build
-Id:        2
-Reason:    COMMIT,BUILDPACK
+Id:              2
+Build Reason:    COMMIT,BUILDPACK
 
 `
 


### PR DESCRIPTION
Issue: https://github.com/vmware-tanzu/kpack-cli/issues/71

I went with `Build Reason` for both image and build status. This is because _sometimes_ with `kp build status` we report `Build Reason` and `Status Reason` to indicate an error with the build for this issue: https://github.com/vmware-tanzu/kpack-cli/issues/42

Using `Build Reason` and `Status Reason` distinguishes the two.

Ex.

```
$ kp build status my-image
Image:             repo.com/image-3:tag
Status:            BUILDING
Build Reason:      TRIGGER
Status Reason:     some-reason
Status Message:    some-message

Pod Name:    some-pod

Builder:      some-repo.com/my-builder
Run Image:    some-repo.com/run-image

Source:    Local Source

BUILDPACK ID    BUILDPACK VERSION
bp-id-1         bp-version-1
bp-id-2         bp-version-2
```

```
$ kp image status my-image
Status:         Not Ready
Message:        --
LatestImage:    test-registry.io/test-image-1@sha256:abcdef123

Last Successful Build
Id:              1
Build Reason:    CONFIG

Last Failed Build
Id:              2
Build Reason:    COMMIT,BUILDPACK
```