### PR TITLE
Allow image cache size to be patched

### DIFF
--- a/pkg/commands/image/create.go
+++ b/pkg/commands/image/create.go
@@ -88,7 +88,7 @@ kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-ho
 	cmd.Flags().StringVarP(&factory.Builder, "builder", "b", "", "builder name")
 	cmd.Flags().StringVarP(&factory.ClusterBuilder, "cluster-builder", "c", "", "cluster builder name")
 	cmd.Flags().StringArrayVar(&factory.Env, "env", []string{}, "build time environment variables")
-	cmd.Flags().StringVar(&factory.CacheSize, "cache-size", "", "cache size (default 2G)")
+	cmd.Flags().StringVar(&factory.CacheSize, "cache-size", "", "cache size as a kubernetes quantity (default \"2G\")")
 	commands.SetTLSFlags(cmd, &factory.TLSConfig)
 	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "wait for image create to be reconciled and tail resulting build logs")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "", false, "only print the object that would be sent, without sending it")

--- a/pkg/commands/image/patch.go
+++ b/pkg/commands/image/patch.go
@@ -46,7 +46,10 @@ For example, "--env key1=value1 --env key2=value2 ...".
 
 Existing environment variables may be deleted by using the "--delete-env" flag.
 For each environment variable, supply the "--delete-env" flag followed by the variable name.
-For example, "--delete-env key1 --delete-env key2 ...".`,
+For example, "--delete-env key1 --delete-env key2 ...".
+
+The --cache-size flag can only be used to increase the size of the existing cache.
+`,
 		Example: `kp image patch my-image --git-revision my-other-branch
 kp image patch my-image --blob https://my-blob-host.com/my-blob
 kp image patch my-image --local-path /path/to/local/source/code
@@ -101,6 +104,7 @@ kp image patch my-image --env foo=bar --env color=red --delete-env apple --delet
 	cmd.Flags().StringVar(&factory.ClusterBuilder, "cluster-builder", "", "cluster builder name")
 	cmd.Flags().StringArrayVarP(&factory.Env, "env", "e", []string{}, "build time environment variables to add/replace")
 	cmd.Flags().StringArrayVarP(&factory.DeleteEnv, "delete-env", "d", []string{}, "build time environment variables to remove")
+	cmd.Flags().StringVar(&factory.CacheSize, "cache-size", "", "cache size as a kubernetes quantity")
 	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "wait for image patch to be reconciled and tail resulting build logs")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "", false, "only print the object that would be sent, without sending it")
 	cmd.Flags().StringVar(&output, "output", "", "output format. supported formats are: yaml, json")

--- a/pkg/commands/image/patch_test.go
+++ b/pkg/commands/image/patch_test.go
@@ -263,6 +263,23 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	it("can patch cache size", func() {
+		testhelpers.CommandTest{
+			Objects: []runtime.Object{
+				img,
+			},
+			Args: []string{
+				"some-image",
+				"--cache-size", "3G",
+			},
+			ExpectedOutput: "\"some-image\" patched\n",
+			ExpectPatches: []string{
+				`{"spec":{"cacheSize":"3G"}}`,
+			},
+		}.TestKpack(t, cmdFunc)
+		assert.Len(t, fakeImageWaiter.Calls, 0)
+	})
+
 	it("will wait on the image update if requested", func() {
 		testhelpers.CommandTest{
 			Objects: []runtime.Object{

--- a/pkg/commands/image/save.go
+++ b/pkg/commands/image/save.go
@@ -31,7 +31,7 @@ func NewSaveCommand(clientSetProvider k8s.ClientSetProvider, factory *image.Fact
 This image will be created only if it does not exist in the provided namespace, otherwise it will be patched.
 
 The --tag flag is required for a create but is immutable and will be ignored for a patch.
-The --cache-size flag can be used for a create but is immutable and will be ignored for a patch.
+The --cache-size flag can only be used to create or increase the size of the existing cache.
 
 The namespace defaults to the kubernetes current-context namespace.
 
@@ -105,7 +105,7 @@ kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host
 	cmd.Flags().StringVar(&factory.Blob, "blob", "", "source code blob url")
 	cmd.Flags().StringVar(&factory.LocalPath, "local-path", "", "path to local source code")
 	cmd.Flags().StringVar(&subPath, "sub-path", "", "build code at the sub path located within the source code directory")
-	cmd.Flags().StringVar(&factory.CacheSize, "cache-size", "", "cache size (default 2G)")
+	cmd.Flags().StringVar(&factory.CacheSize, "cache-size", "", "cache size as a kubernetes quantity (default \"2G\")")
 	cmd.Flags().StringVarP(&factory.Builder, "builder", "b", "", "builder name")
 	cmd.Flags().StringVarP(&factory.ClusterBuilder, "cluster-builder", "c", "", "cluster builder name")
 	cmd.Flags().StringArrayVar(&factory.Env, "env", []string{}, "build time environment variables")

--- a/pkg/commands/image/save_test.go
+++ b/pkg/commands/image/save_test.go
@@ -879,6 +879,23 @@ status: {}
 			})
 		})
 
+		it("can patch cache size", func() {
+			testhelpers.CommandTest{
+				Objects: []runtime.Object{
+					img,
+				},
+				Args: []string{
+					"some-image",
+					"--cache-size", "3G",
+				},
+				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectPatches: []string{
+					`{"spec":{"cacheSize":"3G"}}`,
+				},
+			}.TestKpack(t, cmdFunc)
+			assert.Len(t, fakeImageWaiter.Calls, 0)
+		})
+
 		it("will wait on the image update if requested", func() {
 			testhelpers.CommandTest{
 				Objects: []runtime.Object{

--- a/pkg/image/factory.go
+++ b/pkg/image/factory.go
@@ -126,6 +126,10 @@ func (f *Factory) makeCacheSize() (*resource.Quantity, error) {
 		return nil, nil
 	}
 
+	return f.getCacheSize()
+}
+
+func (f *Factory) getCacheSize() (*resource.Quantity, error) {
 	c, err := resource.ParseQuantity(f.CacheSize)
 	if err != nil {
 		return nil, errors.New("invalid cache size, must be valid quantity ex. 2G")


### PR DESCRIPTION
- Can only be increased
- Include in the flag help text that it must be a kubernetes quantity
eg. 2G

https://github.com/vmware-tanzu/kpack-cli/issues/88