### PR TITLE
Output the resource even if there was no change

### DIFF
--- a/pkg/clusterstack/factory.go
+++ b/pkg/clusterstack/factory.go
@@ -83,7 +83,7 @@ func (f *Factory) UpdateStack(stack *v1alpha1.ClusterStack) (bool, error) {
 	if wasUpdated, err := wasUpdated(stack, relocatedBuildImageRef, relocatedRunImageRef, stackId); err != nil {
 		return false, err
 	} else if !wasUpdated {
-		return false, f.Printer.Printlnf("Build and Run images already exist in stack\nClusterStack Unchanged")
+		return false, f.Printer.Printlnf("Build and Run images already exist in stack")
 	}
 	return true, nil
 }

--- a/pkg/commands/builder/patch.go
+++ b/pkg/commands/builder/patch.go
@@ -88,21 +88,17 @@ func patch(bldr *v1alpha1.Builder, flags CommandFlags, ch *commands.CommandHelpe
 		return err
 	}
 
-	if len(patch) == 0 {
-		return ch.PrintResult("nothing to patch")
-	}
-
-	if !ch.IsDryRun() {
+	hasPatch := len(patch) > 0
+	if hasPatch && !ch.IsDryRun() {
 		patchedBldr, err = cs.KpackClient.KpackV1alpha1().Builders(cs.Namespace).Patch(patchedBldr.Name, types.MergePatchType, patch)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = ch.PrintObj(patchedBldr)
-	if err != nil {
+	if err = ch.PrintObj(patchedBldr); err != nil {
 		return err
 	}
 
-	return ch.PrintResult("%q patched", patchedBldr.Name)
+	return ch.PrintChangeResult(hasPatch, "%q patched", patchedBldr.Name)
 }

--- a/pkg/commands/builder/save_test.go
+++ b/pkg/commands/builder/save_test.go
@@ -28,7 +28,7 @@ func testBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 	const defaultNamespace = "some-default-namespace"
 
 	var (
-		expectedBuilder = &v1alpha1.Builder{
+		bldr = &v1alpha1.Builder{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       v1alpha1.BuilderKind,
 				APIVersion: "kpack.io/v1alpha1",
@@ -86,36 +86,36 @@ func testBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 		it("creates a Builder when it does not exist", func() {
 			testhelpers.CommandTest{
 				Args: []string{
-					expectedBuilder.Name,
-					"--tag", expectedBuilder.Spec.Tag,
-					"--stack", expectedBuilder.Spec.Stack.Name,
-					"--store", expectedBuilder.Spec.Store.Name,
+					bldr.Name,
+					"--tag", bldr.Spec.Tag,
+					"--stack", bldr.Spec.Stack.Name,
+					"--store", bldr.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
-					"-n", expectedBuilder.Namespace,
+					"-n", bldr.Namespace,
 				},
 				ExpectedOutput: `"test-builder" created
 `,
 				ExpectCreates: []runtime.Object{
-					expectedBuilder,
+					bldr,
 				},
 			}.TestKpack(t, cmdFunc)
 		})
 
 		it("creates a Builder with the default namespace, store, and stack", func() {
-			expectedBuilder.Namespace = defaultNamespace
-			expectedBuilder.Spec.Stack.Name = "default"
-			expectedBuilder.Spec.Store.Name = "default"
-			expectedBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"Builder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","namespace":"some-default-namespace","creationTimestamp":null},"spec":{"tag":"some-registry.com/test-builder","stack":{"kind":"ClusterStack","name":"default"},"store":{"kind":"ClusterStore","name":"default"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccount":"default"},"status":{"stack":{}}}`
+			bldr.Namespace = defaultNamespace
+			bldr.Spec.Stack.Name = "default"
+			bldr.Spec.Store.Name = "default"
+			bldr.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"Builder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","namespace":"some-default-namespace","creationTimestamp":null},"spec":{"tag":"some-registry.com/test-builder","stack":{"kind":"ClusterStack","name":"default"},"store":{"kind":"ClusterStore","name":"default"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccount":"default"},"status":{"stack":{}}}`
 
 			testhelpers.CommandTest{
 				Args: []string{
-					expectedBuilder.Name,
-					"--tag", expectedBuilder.Spec.Tag,
+					bldr.Name,
+					"--tag", bldr.Spec.Tag,
 					"--order", "./testdata/order.yaml",
 				},
 				ExpectedOutput: "\"test-builder\" created\n",
 				ExpectCreates: []runtime.Object{
-					expectedBuilder,
+					bldr,
 				},
 			}.TestKpack(t, cmdFunc)
 		})
@@ -150,17 +150,17 @@ status:
 
 				testhelpers.CommandTest{
 					Args: []string{
-						expectedBuilder.Name,
-						"--tag", expectedBuilder.Spec.Tag,
-						"--stack", expectedBuilder.Spec.Stack.Name,
-						"--store", expectedBuilder.Spec.Store.Name,
+						bldr.Name,
+						"--tag", bldr.Spec.Tag,
+						"--stack", bldr.Spec.Stack.Name,
+						"--store", bldr.Spec.Store.Name,
 						"--order", "./testdata/order.yaml",
-						"-n", expectedBuilder.Namespace,
+						"-n", bldr.Namespace,
 						"--output", "yaml",
 					},
 					ExpectedOutput: resourceYAML,
 					ExpectCreates: []runtime.Object{
-						expectedBuilder,
+						bldr,
 					},
 				}.TestKpack(t, cmdFunc)
 			})
@@ -213,17 +213,17 @@ status:
 
 				testhelpers.CommandTest{
 					Args: []string{
-						expectedBuilder.Name,
-						"--tag", expectedBuilder.Spec.Tag,
-						"--stack", expectedBuilder.Spec.Stack.Name,
-						"--store", expectedBuilder.Spec.Store.Name,
+						bldr.Name,
+						"--tag", bldr.Spec.Tag,
+						"--stack", bldr.Spec.Stack.Name,
+						"--store", bldr.Spec.Store.Name,
 						"--order", "./testdata/order.yaml",
-						"-n", expectedBuilder.Namespace,
+						"-n", bldr.Namespace,
 						"--output", "json",
 					},
 					ExpectedOutput: resourceJSON,
 					ExpectCreates: []runtime.Object{
-						expectedBuilder,
+						bldr,
 					},
 				}.TestKpack(t, cmdFunc)
 			})
@@ -233,12 +233,12 @@ status:
 			it("does not create a Builder and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
 					Args: []string{
-						expectedBuilder.Name,
-						"--tag", expectedBuilder.Spec.Tag,
-						"--stack", expectedBuilder.Spec.Stack.Name,
-						"--store", expectedBuilder.Spec.Store.Name,
+						bldr.Name,
+						"--tag", bldr.Spec.Tag,
+						"--stack", bldr.Spec.Stack.Name,
+						"--store", bldr.Spec.Store.Name,
 						"--order", "./testdata/order.yaml",
-						"-n", expectedBuilder.Namespace,
+						"-n", bldr.Namespace,
 						"--dry-run",
 					},
 					ExpectedOutput: `"test-builder" created (dry run)
@@ -276,12 +276,12 @@ status:
 				it("does not create a Builder and prints the resource output", func() {
 					testhelpers.CommandTest{
 						Args: []string{
-							expectedBuilder.Name,
-							"--tag", expectedBuilder.Spec.Tag,
-							"--stack", expectedBuilder.Spec.Stack.Name,
-							"--store", expectedBuilder.Spec.Store.Name,
+							bldr.Name,
+							"--tag", bldr.Spec.Tag,
+							"--stack", bldr.Spec.Stack.Name,
+							"--store", bldr.Spec.Store.Name,
 							"--order", "./testdata/order.yaml",
-							"-n", expectedBuilder.Namespace,
+							"-n", bldr.Namespace,
 							"--dry-run",
 							"--output", "yaml",
 						},
@@ -296,20 +296,34 @@ status:
 		it("patches a Builder when it already exists", func() {
 			testhelpers.CommandTest{
 				Objects: []runtime.Object{
-					expectedBuilder,
+					bldr,
 				},
 				Args: []string{
-					expectedBuilder.Name,
+					bldr.Name,
 					"--tag", "some-other-tag",
 					"--stack", "some-other-stack",
 					"--store", "some-other-store",
 					"--order", "./testdata/patched-order.yaml",
-					"-n", expectedBuilder.Namespace,
+					"-n", bldr.Namespace,
 				},
 				ExpectedOutput: "\"test-builder\" patched\n",
 				ExpectPatches: []string{
 					`{"spec":{"order":[{"group":[{"id":"org.cloudfoundry.test-bp"}]},{"group":[{"id":"org.cloudfoundry.fake-bp"}]}],"stack":{"name":"some-other-stack"},"store":{"name":"some-other-store"},"tag":"some-other-tag"}}`,
 				},
+			}.TestKpack(t, cmdFunc)
+		})
+
+		it("does not patch if there are no changes", func() {
+			testhelpers.CommandTest{
+				Objects: []runtime.Object{
+					bldr,
+				},
+				Args: []string{
+					bldr.Name,
+					"-n", bldr.Namespace,
+				},
+				ExpectedOutput: `"test-builder" patched (no change)
+`,
 			}.TestKpack(t, cmdFunc)
 		})
 
@@ -343,15 +357,15 @@ status:
 
 				testhelpers.CommandTest{
 					Objects: []runtime.Object{
-						expectedBuilder,
+						bldr,
 					},
 					Args: []string{
-						expectedBuilder.Name,
+						bldr.Name,
 						"--tag", "some-other-tag",
 						"--stack", "some-other-stack",
 						"--store", "some-other-store",
 						"--order", "./testdata/patched-order.yaml",
-						"-n", expectedBuilder.Namespace,
+						"-n", bldr.Namespace,
 						"--output", "yaml",
 					},
 					ExpectedOutput: resourceYAML,
@@ -409,15 +423,15 @@ status:
 
 				testhelpers.CommandTest{
 					Objects: []runtime.Object{
-						expectedBuilder,
+						bldr,
 					},
 					Args: []string{
-						expectedBuilder.Name,
+						bldr.Name,
 						"--tag", "some-other-tag",
 						"--stack", "some-other-stack",
 						"--store", "some-other-store",
 						"--order", "./testdata/patched-order.yaml",
-						"-n", expectedBuilder.Namespace,
+						"-n", bldr.Namespace,
 						"--output", "json",
 					},
 					ExpectedOutput: resourceJSON,
@@ -426,26 +440,85 @@ status:
 					},
 				}.TestKpack(t, cmdFunc)
 			})
+
+			when("there are no changes in the patch", func() {
+				it("can output unpatched resource in requested format", func() {
+					const resourceYAML = `apiVersion: kpack.io/v1alpha1
+kind: Builder
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: '{"kind":"Builder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","namespace":"some-namespace","creationTimestamp":null},"spec":{"tag":"some-registry.com/test-builder","stack":{"kind":"ClusterStack","name":"some-stack"},"store":{"kind":"ClusterStore","name":"some-store"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccount":"default"},"status":{"stack":{}}}'
+  creationTimestamp: null
+  name: test-builder
+  namespace: some-namespace
+spec:
+  order:
+  - group:
+    - id: org.cloudfoundry.nodejs
+  - group:
+    - id: org.cloudfoundry.go
+  serviceAccount: default
+  stack:
+    kind: ClusterStack
+    name: some-stack
+  store:
+    kind: ClusterStore
+    name: some-store
+  tag: some-registry.com/test-builder
+status:
+  stack: {}
+`
+
+					testhelpers.CommandTest{
+						Objects: []runtime.Object{
+							bldr,
+						},
+						Args: []string{
+							bldr.Name,
+							"-n", bldr.Namespace,
+							"--output", "yaml",
+						},
+						ExpectedOutput: resourceYAML,
+					}.TestKpack(t, cmdFunc)
+				})
+			})
 		})
 
 		when("dry-run flag is used", func() {
 			it("does not create a Builder and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
 					Objects: []runtime.Object{
-						expectedBuilder,
+						bldr,
 					},
 					Args: []string{
-						expectedBuilder.Name,
+						bldr.Name,
 						"--tag", "some-other-tag",
 						"--stack", "some-other-stack",
 						"--store", "some-other-store",
 						"--order", "./testdata/patched-order.yaml",
-						"-n", expectedBuilder.Namespace,
+						"-n", bldr.Namespace,
 						"--dry-run",
 					},
 					ExpectedOutput: `"test-builder" patched (dry run)
 `,
 				}.TestKpack(t, cmdFunc)
+			})
+
+			when("there are no changes in the patch", func() {
+				it("does not patch and informs of no change", func() {
+					testhelpers.CommandTest{
+						Objects: []runtime.Object{
+							bldr,
+						},
+						Args: []string{
+							bldr.Name,
+							"-n", bldr.Namespace,
+							"--dry-run",
+						},
+						ExpectedOutput: `"test-builder" patched (no change)
+`,
+					}.TestKpack(t, cmdFunc)
+				})
 			})
 
 			when("output flag is used", func() {
@@ -478,15 +551,15 @@ status:
 
 					testhelpers.CommandTest{
 						Objects: []runtime.Object{
-							expectedBuilder,
+							bldr,
 						},
 						Args: []string{
-							expectedBuilder.Name,
+							bldr.Name,
 							"--tag", "some-other-tag",
 							"--stack", "some-other-stack",
 							"--store", "some-other-store",
 							"--order", "./testdata/patched-order.yaml",
-							"-n", expectedBuilder.Namespace,
+							"-n", bldr.Namespace,
 							"--dry-run",
 							"--output", "yaml",
 						},

--- a/pkg/commands/clusterbuilder/patch.go
+++ b/pkg/commands/clusterbuilder/patch.go
@@ -86,21 +86,17 @@ func patch(cb *v1alpha1.ClusterBuilder, flags CommandFlags, ch *commands.Command
 		return err
 	}
 
-	if len(patch) == 0 {
-		return ch.PrintResult("nothing to patch")
-	}
-
-	if !ch.IsDryRun() {
+	hasPatch := len(patch) > 0
+	if hasPatch && !ch.IsDryRun() {
 		patchedCb, err = cs.KpackClient.KpackV1alpha1().ClusterBuilders().Patch(patchedCb.Name, types.MergePatchType, patch)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = ch.PrintObj(patchedCb)
-	if err != nil {
+	if err = ch.PrintObj(patchedCb); err != nil {
 		return err
 	}
 
-	return ch.PrintResult("%q patched", patchedCb.Name)
+	return ch.PrintChangeResult(hasPatch, "%q patched", patchedCb.Name)
 }

--- a/pkg/commands/clusterbuilder/save_test.go
+++ b/pkg/commands/clusterbuilder/save_test.go
@@ -37,7 +37,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		expectedBuilder = &v1alpha1.ClusterBuilder{
+		builder = &v1alpha1.ClusterBuilder{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       v1alpha1.ClusterBuilderKind,
 				APIVersion: "kpack.io/v1alpha1",
@@ -100,37 +100,37 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					config,
 				},
 				Args: []string{
-					expectedBuilder.Name,
-					"--tag", expectedBuilder.Spec.Tag,
-					"--stack", expectedBuilder.Spec.Stack.Name,
-					"--store", expectedBuilder.Spec.Store.Name,
+					builder.Name,
+					"--tag", builder.Spec.Tag,
+					"--stack", builder.Spec.Stack.Name,
+					"--store", builder.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
 				},
 				ExpectedOutput: `"test-builder" created
 `,
 				ExpectCreates: []runtime.Object{
-					expectedBuilder,
+					builder,
 				},
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
 
 		it("creates a ClusterBuilder with the default stack", func() {
-			expectedBuilder.Spec.Stack.Name = "default"
-			expectedBuilder.Spec.Store.Name = "default"
-			expectedBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","creationTimestamp":null},"spec":{"tag":"some-registry/some-project/test-builder","stack":{"kind":"ClusterStack","name":"default"},"store":{"kind":"ClusterStore","name":"default"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
+			builder.Spec.Stack.Name = "default"
+			builder.Spec.Store.Name = "default"
+			builder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","creationTimestamp":null},"spec":{"tag":"some-registry/some-project/test-builder","stack":{"kind":"ClusterStack","name":"default"},"store":{"kind":"ClusterStore","name":"default"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 			testhelpers.CommandTest{
 				K8sObjects: []runtime.Object{
 					config,
 				},
 				Args: []string{
-					expectedBuilder.Name,
-					"--tag", expectedBuilder.Spec.Tag,
+					builder.Name,
+					"--tag", builder.Spec.Tag,
 					"--order", "./testdata/order.yaml",
 				},
 				ExpectedOutput: "\"test-builder\" created\n",
 				ExpectCreates: []runtime.Object{
-					expectedBuilder,
+					builder,
 				},
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -141,15 +141,15 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					config,
 				},
 				Args: []string{
-					expectedBuilder.Name,
-					"--stack", expectedBuilder.Spec.Stack.Name,
-					"--store", expectedBuilder.Spec.Store.Name,
+					builder.Name,
+					"--stack", builder.Spec.Stack.Name,
+					"--store", builder.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
 				},
 				ExpectedOutput: `"test-builder" created
 `,
 				ExpectCreates: []runtime.Object{
-					expectedBuilder,
+					builder,
 				},
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -157,10 +157,10 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 		it("fails when kp-config map is not found", func() {
 			testhelpers.CommandTest{
 				Args: []string{
-					expectedBuilder.Name,
-					"--tag", expectedBuilder.Spec.Tag,
-					"--stack", expectedBuilder.Spec.Stack.Name,
-					"--store", expectedBuilder.Spec.Store.Name,
+					builder.Name,
+					"--tag", builder.Spec.Tag,
+					"--stack", builder.Spec.Stack.Name,
+					"--store", builder.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
 				},
 				ExpectErr: true,
@@ -183,10 +183,10 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					badConfig,
 				},
 				Args: []string{
-					expectedBuilder.Name,
-					"--tag", expectedBuilder.Spec.Tag,
-					"--stack", expectedBuilder.Spec.Stack.Name,
-					"--store", expectedBuilder.Spec.Store.Name,
+					builder.Name,
+					"--tag", builder.Spec.Tag,
+					"--stack", builder.Spec.Stack.Name,
+					"--store", builder.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
 				},
 				ExpectErr: true,
@@ -211,9 +211,9 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					badConfig,
 				},
 				Args: []string{
-					expectedBuilder.Name,
-					"--stack", expectedBuilder.Spec.Stack.Name,
-					"--store", expectedBuilder.Spec.Store.Name,
+					builder.Name,
+					"--stack", builder.Spec.Stack.Name,
+					"--store", builder.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
 				},
 				ExpectErr: true,
@@ -256,16 +256,16 @@ status:
 						config,
 					},
 					Args: []string{
-						expectedBuilder.Name,
-						"--tag", expectedBuilder.Spec.Tag,
-						"--stack", expectedBuilder.Spec.Stack.Name,
-						"--store", expectedBuilder.Spec.Store.Name,
+						builder.Name,
+						"--tag", builder.Spec.Tag,
+						"--stack", builder.Spec.Stack.Name,
+						"--store", builder.Spec.Store.Name,
 						"--order", "./testdata/order.yaml",
 						"--output", "yaml",
 					},
 					ExpectedOutput: resourceYAML,
 					ExpectCreates: []runtime.Object{
-						expectedBuilder,
+						builder,
 					},
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -323,16 +323,16 @@ status:
 						config,
 					},
 					Args: []string{
-						expectedBuilder.Name,
-						"--tag", expectedBuilder.Spec.Tag,
-						"--stack", expectedBuilder.Spec.Stack.Name,
-						"--store", expectedBuilder.Spec.Store.Name,
+						builder.Name,
+						"--tag", builder.Spec.Tag,
+						"--stack", builder.Spec.Stack.Name,
+						"--store", builder.Spec.Store.Name,
 						"--order", "./testdata/order.yaml",
 						"--output", "json",
 					},
 					ExpectedOutput: resourceJSON,
 					ExpectCreates: []runtime.Object{
-						expectedBuilder,
+						builder,
 					},
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -345,10 +345,10 @@ status:
 						config,
 					},
 					Args: []string{
-						expectedBuilder.Name,
-						"--tag", expectedBuilder.Spec.Tag,
-						"--stack", expectedBuilder.Spec.Stack.Name,
-						"--store", expectedBuilder.Spec.Store.Name,
+						builder.Name,
+						"--tag", builder.Spec.Tag,
+						"--stack", builder.Spec.Stack.Name,
+						"--store", builder.Spec.Store.Name,
 						"--order", "./testdata/order.yaml",
 						"--dry-run",
 					},
@@ -391,10 +391,10 @@ status:
 							config,
 						},
 						Args: []string{
-							expectedBuilder.Name,
-							"--tag", expectedBuilder.Spec.Tag,
-							"--stack", expectedBuilder.Spec.Stack.Name,
-							"--store", expectedBuilder.Spec.Store.Name,
+							builder.Name,
+							"--tag", builder.Spec.Tag,
+							"--stack", builder.Spec.Stack.Name,
+							"--store", builder.Spec.Store.Name,
 							"--order", "./testdata/order.yaml",
 							"--dry-run",
 							"--output", "yaml",
@@ -410,10 +410,10 @@ status:
 		it("patches when the ClusterBuilder does exist", func() {
 			testhelpers.CommandTest{
 				KpackObjects: []runtime.Object{
-					expectedBuilder,
+					builder,
 				},
 				Args: []string{
-					expectedBuilder.Name,
+					builder.Name,
 					"--tag", "some-other-tag",
 					"--stack", "some-other-stack",
 					"--store", "some-other-store",
@@ -423,6 +423,19 @@ status:
 				ExpectPatches: []string{
 					`{"spec":{"order":[{"group":[{"id":"org.cloudfoundry.test-bp"}]},{"group":[{"id":"org.cloudfoundry.fake-bp"}]}],"stack":{"name":"some-other-stack"},"store":{"name":"some-other-store"},"tag":"some-other-tag"}}`,
 				},
+			}.TestK8sAndKpack(t, cmdFunc)
+		})
+
+		it("does not patch if there are no changes", func() {
+			testhelpers.CommandTest{
+				KpackObjects: []runtime.Object{
+					builder,
+				},
+				Args: []string{
+					builder.Name,
+				},
+				ExpectedOutput: `"test-builder" patched (no change)
+`,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
 
@@ -457,10 +470,10 @@ status:
 
 				testhelpers.CommandTest{
 					KpackObjects: []runtime.Object{
-						expectedBuilder,
+						builder,
 					},
 					Args: []string{
-						expectedBuilder.Name,
+						builder.Name,
 						"--tag", "some-other-tag",
 						"--stack", "some-other-stack",
 						"--store", "some-other-store",
@@ -524,10 +537,10 @@ status:
 
 				testhelpers.CommandTest{
 					KpackObjects: []runtime.Object{
-						expectedBuilder,
+						builder,
 					},
 					Args: []string{
-						expectedBuilder.Name,
+						builder.Name,
 						"--tag", "some-other-tag",
 						"--stack", "some-other-stack",
 						"--store", "some-other-store",
@@ -540,16 +553,58 @@ status:
 					},
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
+
+			when("there are no changes in the patch", func() {
+				it("can output unpatched resource in requested format", func() {
+					const resourceYAML = `apiVersion: kpack.io/v1alpha1
+kind: ClusterBuilder
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: '{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","creationTimestamp":null},"spec":{"tag":"some-registry/some-project/test-builder","stack":{"kind":"ClusterStack","name":"some-stack"},"store":{"kind":"ClusterStore","name":"some-store"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}'
+  creationTimestamp: null
+  name: test-builder
+spec:
+  order:
+  - group:
+    - id: org.cloudfoundry.nodejs
+  - group:
+    - id: org.cloudfoundry.go
+  serviceAccountRef:
+    name: some-serviceaccount
+    namespace: kpack
+  stack:
+    kind: ClusterStack
+    name: some-stack
+  store:
+    kind: ClusterStore
+    name: some-store
+  tag: some-registry/some-project/test-builder
+status:
+  stack: {}
+`
+
+					testhelpers.CommandTest{
+						KpackObjects: []runtime.Object{
+							builder,
+						},
+						Args: []string{
+							builder.Name,
+							"--output", "yaml",
+						},
+						ExpectedOutput: resourceYAML,
+					}.TestK8sAndKpack(t, cmdFunc)
+				})
+			})
 		})
 
 		when("dry-run flag is used", func() {
 			it("does not patch a ClusterBuilder and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
 					KpackObjects: []runtime.Object{
-						expectedBuilder,
+						builder,
 					},
 					Args: []string{
-						expectedBuilder.Name,
+						builder.Name,
 						"--tag", "some-other-tag",
 						"--stack", "some-other-stack",
 						"--store", "some-other-store",
@@ -559,6 +614,22 @@ status:
 					ExpectedOutput: `"test-builder" patched (dry run)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
+			})
+
+			when("there are no changes in the patch", func() {
+				it("does not patch and informs of no change", func() {
+					testhelpers.CommandTest{
+						KpackObjects: []runtime.Object{
+							builder,
+						},
+						Args: []string{
+							builder.Name,
+							"--dry-run",
+						},
+						ExpectedOutput: `"test-builder" patched (no change)
+`,
+					}.TestK8sAndKpack(t, cmdFunc)
+				})
 			})
 
 			when("output flag is used", func() {
@@ -592,10 +663,10 @@ status:
 
 					testhelpers.CommandTest{
 						KpackObjects: []runtime.Object{
-							expectedBuilder,
+							builder,
 						},
 						Args: []string{
-							expectedBuilder.Name,
+							builder.Name,
 							"--tag", "some-other-tag",
 							"--stack", "some-other-stack",
 							"--store", "some-other-store",

--- a/pkg/commands/clusterstack/update.go
+++ b/pkg/commands/clusterstack/update.go
@@ -83,13 +83,12 @@ func update(stack *v1alpha1.ClusterStack, factory *clusterstack.Factory, ch *com
 		return err
 	}
 
-	if wasUpdated, err := factory.UpdateStack(stack); err != nil {
+	hasUpdates, err := factory.UpdateStack(stack)
+	if err != nil {
 		return err
-	} else if !wasUpdated {
-		return nil
 	}
 
-	if !ch.IsDryRun() {
+	if hasUpdates && !ch.IsDryRun() {
 		stack, err = cs.KpackClient.KpackV1alpha1().ClusterStacks().Update(stack)
 		if err != nil {
 			return err
@@ -100,5 +99,5 @@ func update(stack *v1alpha1.ClusterStack, factory *clusterstack.Factory, ch *com
 		return err
 	}
 
-	return ch.PrintResult("%q updated", stack.Name)
+	return ch.PrintChangeResult(hasUpdates, "%q updated", stack.Name)
 }

--- a/pkg/commands/clusterstore/add.go
+++ b/pkg/commands/clusterstore/add.go
@@ -84,11 +84,7 @@ func update(store *v1alpha1.ClusterStore, buildpackages []string, factory *clust
 		return err
 	}
 
-	if !storeUpdated {
-		return ch.Printlnf("ClusterStore Unchanged")
-	}
-
-	if !ch.IsDryRun() {
+	if storeUpdated && !ch.IsDryRun() {
 		updatedStore, err = cs.KpackClient.KpackV1alpha1().ClusterStores().Update(updatedStore)
 		if err != nil {
 			return err
@@ -99,5 +95,5 @@ func update(store *v1alpha1.ClusterStore, buildpackages []string, factory *clust
 		return err
 	}
 
-	return ch.PrintResult("ClusterStore Updated")
+	return ch.PrintChangeResult(storeUpdated, "ClusterStore Updated")
 }

--- a/pkg/commands/image/patch_test.go
+++ b/pkg/commands/image/patch_test.go
@@ -80,7 +80,7 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 	}
 
 	when("no parameters are provided", func() {
-		it("does not create a patch", func() {
+		it("informs user of no change in patch and does not wait", func() {
 			testhelpers.CommandTest{
 				Objects: []runtime.Object{
 					img,
@@ -88,7 +88,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 				Args: []string{
 					"some-image",
 				},
-				ExpectedOutput: "nothing to patch\n",
+				ExpectedOutput: `"some-image" patched (no change)
+`,
 			}.TestKpack(t, cmdFunc)
 			assert.Len(t, fakeImageWaiter.Calls, 0)
 		})
@@ -306,22 +307,6 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("output flag is used", func() {
-		when("no parameters are provided", func() {
-			it("does not give output and informs user of nothing to patch", func() {
-				testhelpers.CommandTest{
-					Objects: []runtime.Object{
-						img,
-					},
-					Args: []string{
-						"some-image",
-						"--output", "yaml",
-					},
-					ExpectedErrorOutput: "nothing to patch\n",
-				}.TestKpack(t, cmdFunc)
-				assert.Len(t, fakeImageWaiter.Calls, 0)
-			})
-		})
-
 		it("can output resources in yaml and does not wait", func() {
 			const resourceYAML = `apiVersion: kpack.io/v1alpha1
 kind: Image
@@ -422,24 +407,49 @@ status: {}
 			}.TestKpack(t, cmdFunc)
 			assert.Len(t, fakeImageWaiter.Calls, 0)
 		})
-	})
 
-	when("dry-run flag is used", func() {
-		when("no parameters are provided", func() {
-			it("informs user of nothing to patch", func() {
+		when("there are no changes in the patch", func() {
+			it("can output unpatched resource in requested format and does not wait", func() {
 				testhelpers.CommandTest{
 					Objects: []runtime.Object{
 						img,
 					},
 					Args: []string{
 						"some-image",
-						"--dry-run",
+						"--output", "yaml",
 					},
-					ExpectedOutput: "nothing to patch\n",
+					ExpectedOutput: `apiVersion: kpack.io/v1alpha1
+kind: Image
+metadata:
+  creationTimestamp: null
+  name: some-image
+  namespace: some-default-namespace
+spec:
+  build:
+    env:
+    - name: key1
+      value: value1
+    - name: key2
+      value: value2
+    resources: {}
+  builder:
+    kind: ClusterBuilder
+    name: some-ccb
+  source:
+    git:
+      revision: some-revision
+      url: some-git-url
+    subPath: some-path
+  tag: some-tag
+status: {}
+`,
 				}.TestKpack(t, cmdFunc)
+				assert.Len(t, fakeImageWaiter.Calls, 0)
 			})
 		})
+	})
 
+	when("dry-run flag is used", func() {
 		it("does not patch and prints result message with dry run indicated", func() {
 			testhelpers.CommandTest{
 				Objects: []runtime.Object{
@@ -455,6 +465,22 @@ status: {}
 `,
 			}.TestKpack(t, cmdFunc)
 			assert.Len(t, fakeImageWaiter.Calls, 0)
+		})
+
+		when("there are no changes in the patch", func() {
+			it("does not patch and informs of no change", func() {
+				testhelpers.CommandTest{
+					Objects: []runtime.Object{
+						img,
+					},
+					Args: []string{
+						"some-image",
+						"--dry-run",
+					},
+					ExpectedOutput: `"some-image" patched (no change)
+`,
+				}.TestKpack(t, cmdFunc)
+			})
 		})
 
 		when("output flag is used", func() {

--- a/pkg/commands/secret/create.go
+++ b/pkg/commands/secret/create.go
@@ -85,8 +85,7 @@ kp secret create my-git-cred --git-url https://github.com --git-user my-git-user
 				}
 			}
 
-			err = ch.PrintObj(secret)
-			if err != nil {
+			if err = ch.PrintObj(secret); err != nil {
 				return err
 			}
 
@@ -101,8 +100,7 @@ kp secret create my-git-cred --git-url https://github.com --git-user my-git-user
 				serviceAccount.ImagePullSecrets = append(serviceAccount.ImagePullSecrets, corev1.LocalObjectReference{Name: args[0]})
 			}
 
-			err = updateManagedSecretsAnnotation(err, serviceAccount, args[0], target)
-			if err != nil {
+			if err = updateManagedSecretsAnnotation(err, serviceAccount, args[0], target); err != nil {
 				return err
 			}
 
@@ -113,8 +111,7 @@ kp secret create my-git-cred --git-url https://github.com --git-user my-git-user
 				}
 			}
 
-			err = ch.PrintObj(serviceAccount)
-			if err != nil {
+			if err = ch.PrintObj(serviceAccount); err != nil {
 				return err
 			}
 

--- a/pkg/k8s/last_applied_configuration.go
+++ b/pkg/k8s/last_applied_configuration.go
@@ -1,3 +1,6 @@
+// Copyright 2020-Present VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (


### PR DESCRIPTION
When `--output` flag is used and the command has made no update, it should
still print the existing resource.

 Applicable to:
- image patch/save
- clusterstack update/save
- clusterstore add/save
- clusterbuilder patch/save
- builder patch/save

kubectl uses the `(no change)` suffix on the operation if there is no change, so went with that approach.

Issue: https://github.com/vmware-tanzu/kpack-cli/issues/37