### PR TITLE
Output formatting

### DIFF
--- a/pkg/commands/builder/create.go
+++ b/pkg/commands/builder/create.go
@@ -126,5 +126,5 @@ func create(name string, flags CommandFlags, ch *commands.CommandHelper, cs k8s.
 		return err
 	}
 
-	return ch.PrintResult("%q created", bldr.Name)
+	return ch.PrintResult("Builder %q created", bldr.Name)
 }

--- a/pkg/commands/builder/create_test.go
+++ b/pkg/commands/builder/create_test.go
@@ -92,7 +92,7 @@ func testBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--order", "./testdata/order.yaml",
 				"-n", expectedBuilder.Namespace,
 			},
-			ExpectedOutput: `"test-builder" created
+			ExpectedOutput: `Builder "test-builder" created
 `,
 			ExpectCreates: []runtime.Object{
 				expectedBuilder,
@@ -112,7 +112,8 @@ func testBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--tag", expectedBuilder.Spec.Tag,
 				"--order", "./testdata/order.yaml",
 			},
-			ExpectedOutput: "\"test-builder\" created\n",
+			ExpectedOutput: `Builder "test-builder" created
+`,
 			ExpectCreates: []runtime.Object{
 				expectedBuilder,
 			},
@@ -240,7 +241,7 @@ status:
 					"-n", expectedBuilder.Namespace,
 					"--dry-run",
 				},
-				ExpectedOutput: `"test-builder" created (dry run)
+				ExpectedOutput: `Builder "test-builder" created (dry run)
 `,
 			}.TestKpack(t, cmdFunc)
 		})

--- a/pkg/commands/builder/delete.go
+++ b/pkg/commands/builder/delete.go
@@ -37,7 +37,7 @@ The namespace defaults to the kubernetes current-context namespace.`,
 				return err
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "\"%s\" deleted\n", args[0])
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Builder %q deleted\n", args[0])
 			return err
 		},
 		SilenceUsage: true,

--- a/pkg/commands/builder/delete_test.go
+++ b/pkg/commands/builder/delete_test.go
@@ -43,8 +43,9 @@ func testBuilderDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 					Objects: []runtime.Object{
 						builder,
 					},
-					Args:           []string{"-n", "test-namespace", "some-builder"},
-					ExpectedOutput: "\"some-builder\" deleted\n",
+					Args: []string{"-n", "test-namespace", "some-builder"},
+					ExpectedOutput: `Builder "some-builder" deleted
+`,
 					ExpectDeletes: []clientgotesting.DeleteActionImpl{
 						{
 							ActionImpl: clientgotesting.ActionImpl{
@@ -90,8 +91,9 @@ func testBuilderDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 					Objects: []runtime.Object{
 						builder,
 					},
-					Args:           []string{"some-builder"},
-					ExpectedOutput: "\"some-builder\" deleted\n",
+					Args: []string{"some-builder"},
+					ExpectedOutput: `Builder "some-builder" deleted
+`,
 					ExpectDeletes: []clientgotesting.DeleteActionImpl{
 						{
 							ActionImpl: clientgotesting.ActionImpl{

--- a/pkg/commands/builder/patch.go
+++ b/pkg/commands/builder/patch.go
@@ -100,5 +100,5 @@ func patch(bldr *v1alpha1.Builder, flags CommandFlags, ch *commands.CommandHelpe
 		return err
 	}
 
-	return ch.PrintChangeResult(hasPatch, "%q patched", patchedBldr.Name)
+	return ch.PrintChangeResult(hasPatch, "Builder %q patched", patchedBldr.Name)
 }

--- a/pkg/commands/builder/patch_test.go
+++ b/pkg/commands/builder/patch_test.go
@@ -91,7 +91,8 @@ func testBuilderPatchCommand(t *testing.T, when spec.G, it spec.S) {
 				"--order", "./testdata/patched-order.yaml",
 				"-n", bldr.Namespace,
 			},
-			ExpectedOutput: "\"test-builder\" patched\n",
+			ExpectedOutput: `Builder "test-builder" patched
+`,
 			ExpectPatches: []string{
 				`{"spec":{"order":[{"group":[{"id":"org.cloudfoundry.test-bp"}]},{"group":[{"id":"org.cloudfoundry.fake-bp"}]}],"stack":{"name":"some-other-stack"},"store":{"name":"some-other-store"},"tag":"some-other-tag"}}`,
 			},
@@ -112,7 +113,8 @@ func testBuilderPatchCommand(t *testing.T, when spec.G, it spec.S) {
 				"--store", "some-other-store",
 				"--order", "./testdata/patched-order.yaml",
 			},
-			ExpectedOutput: "\"test-builder\" patched\n",
+			ExpectedOutput: `Builder "test-builder" patched
+`,
 			ExpectPatches: []string{
 				`{"spec":{"order":[{"group":[{"id":"org.cloudfoundry.test-bp"}]},{"group":[{"id":"org.cloudfoundry.fake-bp"}]}],"stack":{"name":"some-other-stack"},"store":{"name":"some-other-store"},"tag":"some-other-tag"}}`,
 			},
@@ -128,7 +130,7 @@ func testBuilderPatchCommand(t *testing.T, when spec.G, it spec.S) {
 				bldr.Name,
 				"-n", bldr.Namespace,
 			},
-			ExpectedOutput: `"test-builder" patched (no change)
+			ExpectedOutput: `Builder "test-builder" patched (no change)
 `,
 		}.TestKpack(t, cmdFunc)
 	})
@@ -298,7 +300,7 @@ status:
 					"-n", bldr.Namespace,
 					"--dry-run",
 				},
-				ExpectedOutput: `"test-builder" patched (dry run)
+				ExpectedOutput: `Builder "test-builder" patched (dry run)
 `,
 			}.TestKpack(t, cmdFunc)
 		})
@@ -314,7 +316,7 @@ status:
 						"-n", bldr.Namespace,
 						"--dry-run",
 					},
-					ExpectedOutput: `"test-builder" patched (no change)
+					ExpectedOutput: `Builder "test-builder" patched (no change)
 `,
 				}.TestKpack(t, cmdFunc)
 			})

--- a/pkg/commands/builder/save_test.go
+++ b/pkg/commands/builder/save_test.go
@@ -93,7 +93,7 @@ func testBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					"--order", "./testdata/order.yaml",
 					"-n", bldr.Namespace,
 				},
-				ExpectedOutput: `"test-builder" created
+				ExpectedOutput: `Builder "test-builder" created
 `,
 				ExpectCreates: []runtime.Object{
 					bldr,
@@ -113,7 +113,8 @@ func testBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					"--tag", bldr.Spec.Tag,
 					"--order", "./testdata/order.yaml",
 				},
-				ExpectedOutput: "\"test-builder\" created\n",
+				ExpectedOutput: `Builder "test-builder" created
+`,
 				ExpectCreates: []runtime.Object{
 					bldr,
 				},
@@ -241,7 +242,7 @@ status:
 						"-n", bldr.Namespace,
 						"--dry-run",
 					},
-					ExpectedOutput: `"test-builder" created (dry run)
+					ExpectedOutput: `Builder "test-builder" created (dry run)
 `,
 				}.TestKpack(t, cmdFunc)
 			})
@@ -306,7 +307,8 @@ status:
 					"--order", "./testdata/patched-order.yaml",
 					"-n", bldr.Namespace,
 				},
-				ExpectedOutput: "\"test-builder\" patched\n",
+				ExpectedOutput: `Builder "test-builder" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"order":[{"group":[{"id":"org.cloudfoundry.test-bp"}]},{"group":[{"id":"org.cloudfoundry.fake-bp"}]}],"stack":{"name":"some-other-stack"},"store":{"name":"some-other-store"},"tag":"some-other-tag"}}`,
 				},
@@ -322,7 +324,7 @@ status:
 					bldr.Name,
 					"-n", bldr.Namespace,
 				},
-				ExpectedOutput: `"test-builder" patched (no change)
+				ExpectedOutput: `Builder "test-builder" patched (no change)
 `,
 			}.TestKpack(t, cmdFunc)
 		})
@@ -499,7 +501,7 @@ status:
 						"-n", bldr.Namespace,
 						"--dry-run",
 					},
-					ExpectedOutput: `"test-builder" patched (dry run)
+					ExpectedOutput: `Builder "test-builder" patched (dry run)
 `,
 				}.TestKpack(t, cmdFunc)
 			})
@@ -515,7 +517,7 @@ status:
 							"-n", bldr.Namespace,
 							"--dry-run",
 						},
-						ExpectedOutput: `"test-builder" patched (no change)
+						ExpectedOutput: `Builder "test-builder" patched (no change)
 `,
 					}.TestKpack(t, cmdFunc)
 				})

--- a/pkg/commands/clusterbuilder/create.go
+++ b/pkg/commands/clusterbuilder/create.go
@@ -146,5 +146,5 @@ func create(name string, flags CommandFlags, ch *commands.CommandHelper, cs k8s.
 		return err
 	}
 
-	return ch.PrintResult("%q created", cb.Name)
+	return ch.PrintResult("ClusterBuilder %q created", cb.Name)
 }

--- a/pkg/commands/clusterbuilder/create_test.go
+++ b/pkg/commands/clusterbuilder/create_test.go
@@ -105,7 +105,7 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--store", expectedBuilder.Spec.Store.Name,
 				"--order", "./testdata/order.yaml",
 			},
-			ExpectedOutput: `"test-builder" created
+			ExpectedOutput: `ClusterBuilder "test-builder" created
 `,
 			ExpectCreates: []runtime.Object{
 				expectedBuilder,
@@ -127,7 +127,8 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--tag", expectedBuilder.Spec.Tag,
 				"--order", "./testdata/order.yaml",
 			},
-			ExpectedOutput: "\"test-builder\" created\n",
+			ExpectedOutput: `ClusterBuilder "test-builder" created
+`,
 			ExpectCreates: []runtime.Object{
 				expectedBuilder,
 			},
@@ -145,7 +146,7 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--store", expectedBuilder.Spec.Store.Name,
 				"--order", "./testdata/order.yaml",
 			},
-			ExpectedOutput: `"test-builder" created
+			ExpectedOutput: `ClusterBuilder "test-builder" created
 `,
 			ExpectCreates: []runtime.Object{
 				expectedBuilder,
@@ -351,7 +352,7 @@ status:
 					"--order", "./testdata/order.yaml",
 					"--dry-run",
 				},
-				ExpectedOutput: `"test-builder" created (dry run)
+				ExpectedOutput: `ClusterBuilder "test-builder" created (dry run)
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})

--- a/pkg/commands/clusterbuilder/delete.go
+++ b/pkg/commands/clusterbuilder/delete.go
@@ -31,7 +31,7 @@ func NewDeleteCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "\"%s\" deleted\n", args[0])
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "ClusterBuilder %q deleted\n", args[0])
 			return err
 		},
 		SilenceUsage: true,

--- a/pkg/commands/clusterbuilder/delete_test.go
+++ b/pkg/commands/clusterbuilder/delete_test.go
@@ -40,8 +40,9 @@ func testClusterBuilderDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 				Objects: []runtime.Object{
 					clusterBuilder,
 				},
-				Args:           []string{"some-clusterbuilder"},
-				ExpectedOutput: "\"some-clusterbuilder\" deleted\n",
+				Args: []string{"some-clusterbuilder"},
+				ExpectedOutput: `ClusterBuilder "some-clusterbuilder" deleted
+`,
 				ExpectDeletes: []clientgotesting.DeleteActionImpl{
 					{
 						Name: clusterBuilder.Name,

--- a/pkg/commands/clusterbuilder/patch.go
+++ b/pkg/commands/clusterbuilder/patch.go
@@ -98,5 +98,5 @@ func patch(cb *v1alpha1.ClusterBuilder, flags CommandFlags, ch *commands.Command
 		return err
 	}
 
-	return ch.PrintChangeResult(hasPatch, "%q patched", patchedCb.Name)
+	return ch.PrintChangeResult(hasPatch, "ClusterBuilder %q patched", patchedCb.Name)
 }

--- a/pkg/commands/clusterbuilder/patch_test.go
+++ b/pkg/commands/clusterbuilder/patch_test.go
@@ -89,7 +89,8 @@ func testClusterBuilderPatchCommand(t *testing.T, when spec.G, it spec.S) {
 				"--store", "some-other-store",
 				"--order", "./testdata/patched-order.yaml",
 			},
-			ExpectedOutput: "\"test-builder\" patched\n",
+			ExpectedOutput: `ClusterBuilder "test-builder" patched
+`,
 			ExpectPatches: []string{
 				`{"spec":{"order":[{"group":[{"id":"org.cloudfoundry.test-bp"}]},{"group":[{"id":"org.cloudfoundry.fake-bp"}]}],"stack":{"name":"some-other-stack"},"store":{"name":"some-other-store"},"tag":"some-other-tag"}}`,
 			},
@@ -104,7 +105,7 @@ func testClusterBuilderPatchCommand(t *testing.T, when spec.G, it spec.S) {
 			Args: []string{
 				builder.Name,
 			},
-			ExpectedOutput: `"test-builder" patched (no change)
+			ExpectedOutput: `ClusterBuilder "test-builder" patched (no change)
 `,
 		}.TestKpack(t, cmdFunc)
 	})
@@ -274,7 +275,7 @@ status:
 					"--order", "./testdata/patched-order.yaml",
 					"--dry-run",
 				},
-				ExpectedOutput: `"test-builder" patched (dry run)
+				ExpectedOutput: `ClusterBuilder "test-builder" patched (dry run)
 `,
 			}.TestKpack(t, cmdFunc)
 		})
@@ -289,7 +290,7 @@ status:
 						builder.Name,
 						"--dry-run",
 					},
-					ExpectedOutput: `"test-builder" patched (no change)
+					ExpectedOutput: `ClusterBuilder "test-builder" patched (no change)
 `,
 				}.TestKpack(t, cmdFunc)
 			})

--- a/pkg/commands/clusterbuilder/save_test.go
+++ b/pkg/commands/clusterbuilder/save_test.go
@@ -106,7 +106,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					"--store", builder.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
 				},
-				ExpectedOutput: `"test-builder" created
+				ExpectedOutput: `ClusterBuilder "test-builder" created
 `,
 				ExpectCreates: []runtime.Object{
 					builder,
@@ -128,7 +128,8 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					"--tag", builder.Spec.Tag,
 					"--order", "./testdata/order.yaml",
 				},
-				ExpectedOutput: "\"test-builder\" created\n",
+				ExpectedOutput: `ClusterBuilder "test-builder" created
+`,
 				ExpectCreates: []runtime.Object{
 					builder,
 				},
@@ -146,7 +147,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					"--store", builder.Spec.Store.Name,
 					"--order", "./testdata/order.yaml",
 				},
-				ExpectedOutput: `"test-builder" created
+				ExpectedOutput: `ClusterBuilder "test-builder" created
 `,
 				ExpectCreates: []runtime.Object{
 					builder,
@@ -352,7 +353,7 @@ status:
 						"--order", "./testdata/order.yaml",
 						"--dry-run",
 					},
-					ExpectedOutput: `"test-builder" created (dry run)
+					ExpectedOutput: `ClusterBuilder "test-builder" created (dry run)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -419,7 +420,8 @@ status:
 					"--store", "some-other-store",
 					"--order", "./testdata/patched-order.yaml",
 				},
-				ExpectedOutput: "\"test-builder\" patched\n",
+				ExpectedOutput: `ClusterBuilder "test-builder" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"order":[{"group":[{"id":"org.cloudfoundry.test-bp"}]},{"group":[{"id":"org.cloudfoundry.fake-bp"}]}],"stack":{"name":"some-other-stack"},"store":{"name":"some-other-store"},"tag":"some-other-tag"}}`,
 				},
@@ -434,7 +436,7 @@ status:
 				Args: []string{
 					builder.Name,
 				},
-				ExpectedOutput: `"test-builder" patched (no change)
+				ExpectedOutput: `ClusterBuilder "test-builder" patched (no change)
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -611,7 +613,7 @@ status:
 						"--order", "./testdata/patched-order.yaml",
 						"--dry-run",
 					},
-					ExpectedOutput: `"test-builder" patched (dry run)
+					ExpectedOutput: `ClusterBuilder "test-builder" patched (dry run)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -626,7 +628,7 @@ status:
 							builder.Name,
 							"--dry-run",
 						},
-						ExpectedOutput: `"test-builder" patched (no change)
+						ExpectedOutput: `ClusterBuilder "test-builder" patched (no change)
 `,
 					}.TestK8sAndKpack(t, cmdFunc)
 				})

--- a/pkg/commands/clusterstack/create.go
+++ b/pkg/commands/clusterstack/create.go
@@ -85,5 +85,5 @@ func create(name string, factory *clusterstack.Factory, ch *commands.CommandHelp
 		return err
 	}
 
-	return ch.PrintResult("%q created", stack.Name)
+	return ch.PrintResult("ClusterStack %q created", stack.Name)
 }

--- a/pkg/commands/clusterstack/create_test.go
+++ b/pkg/commands/clusterstack/create_test.go
@@ -88,7 +88,7 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 			},
 			ExpectedOutput: `Creating ClusterStack...
 Uploading to 'some-registry.io/some-repo'...
-"some-stack" created
+ClusterStack "some-stack" created
 `,
 			ExpectCreates: []runtime.Object{
 				expectedStack,
@@ -270,7 +270,7 @@ Uploading to 'some-registry.io/some-repo'...
 				},
 				ExpectedOutput: `Creating ClusterStack... (dry run)
 Uploading to 'some-registry.io/some-repo'...
-"some-stack" created (dry run)
+ClusterStack "some-stack" created (dry run)
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})

--- a/pkg/commands/clusterstack/delete.go
+++ b/pkg/commands/clusterstack/delete.go
@@ -31,7 +31,7 @@ func NewDeleteCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "\"%s\" deleted\n", args[0])
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "ClusterStack %q deleted\n", args[0])
 			return err
 		},
 		SilenceUsage: true,

--- a/pkg/commands/clusterstack/delete_test.go
+++ b/pkg/commands/clusterstack/delete_test.go
@@ -41,7 +41,7 @@ func testClusterStackDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 					stack,
 				},
 				Args:           []string{"some-stack"},
-				ExpectedOutput: "\"some-stack\" deleted\n",
+				ExpectedOutput: "ClusterStack \"some-stack\" deleted\n",
 				ExpectDeletes: []clientgotesting.DeleteActionImpl{
 					{
 						Name: stack.Name,

--- a/pkg/commands/clusterstack/save_test.go
+++ b/pkg/commands/clusterstack/save_test.go
@@ -95,7 +95,7 @@ func testSaveCommand(t *testing.T, when spec.G, it spec.S) {
 				},
 				ExpectedOutput: `Creating ClusterStack...
 Uploading to 'some-registry.io/some-repo'...
-"some-stack" created
+ClusterStack "some-stack" created
 `,
 				ExpectCreates: []runtime.Object{
 					expectedStack,
@@ -277,7 +277,7 @@ Uploading to 'some-registry.io/some-repo'...
 					},
 					ExpectedOutput: `Creating ClusterStack... (dry run)
 Uploading to 'some-registry.io/some-repo'...
-"some-stack" created (dry run)
+ClusterStack "some-stack" created (dry run)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -379,7 +379,7 @@ Uploading to 'some-registry.io/some-repo'...
 				},
 				ExpectedOutput: `Updating ClusterStack...
 Uploading to 'some-registry.io/some-repo'...
-"some-stack" updated
+ClusterStack "some-stack" updated
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -400,7 +400,7 @@ Uploading to 'some-registry.io/some-repo'...
 				ExpectedOutput: `Updating ClusterStack...
 Uploading to 'some-registry.io/some-repo'...
 Build and Run images already exist in stack
-"some-stack" updated (no change)
+ClusterStack "some-stack" updated (no change)
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -596,7 +596,7 @@ Build and Run images already exist in stack
 					},
 					ExpectedOutput: `Updating ClusterStack... (dry run)
 Uploading to 'some-registry.io/some-repo'...
-"some-stack" updated (dry run)
+ClusterStack "some-stack" updated (dry run)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -619,7 +619,7 @@ Uploading to 'some-registry.io/some-repo'...
 						ExpectedOutput: `Updating ClusterStack... (dry run)
 Uploading to 'some-registry.io/some-repo'...
 Build and Run images already exist in stack
-"some-stack" updated (no change)
+ClusterStack "some-stack" updated (no change)
 `,
 					}.TestK8sAndKpack(t, cmdFunc)
 				})

--- a/pkg/commands/clusterstack/update.go
+++ b/pkg/commands/clusterstack/update.go
@@ -99,5 +99,5 @@ func update(stack *v1alpha1.ClusterStack, factory *clusterstack.Factory, ch *com
 		return err
 	}
 
-	return ch.PrintChangeResult(hasUpdates, "%q updated", stack.Name)
+	return ch.PrintChangeResult(hasUpdates, "ClusterStack %q updated", stack.Name)
 }

--- a/pkg/commands/clusterstack/update_test.go
+++ b/pkg/commands/clusterstack/update_test.go
@@ -125,7 +125,7 @@ func testUpdateCommand(t *testing.T, when spec.G, it spec.S) {
 			},
 			ExpectedOutput: `Updating ClusterStack...
 Uploading to 'some-registry.com/some-repo'...
-"some-stack" updated
+ClusterStack "some-stack" updated
 `,
 		}.TestK8sAndKpack(t, cmdFunc)
 	})
@@ -143,7 +143,7 @@ Uploading to 'some-registry.com/some-repo'...
 			ExpectedOutput: `Updating ClusterStack...
 Uploading to 'some-registry.com/some-repo'...
 Build and Run images already exist in stack
-"some-stack" updated (no change)
+ClusterStack "some-stack" updated (no change)
 `,
 		}.TestK8sAndKpack(t, cmdFunc)
 	})
@@ -394,7 +394,7 @@ Build and Run images already exist in stack
 				},
 				ExpectedOutput: `Updating ClusterStack... (dry run)
 Uploading to 'some-registry.com/some-repo'...
-"some-stack" updated (dry run)
+ClusterStack "some-stack" updated (dry run)
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -417,7 +417,7 @@ Uploading to 'some-registry.com/some-repo'...
 					ExpectedOutput: `Updating ClusterStack... (dry run)
 Uploading to 'some-registry.com/some-repo'...
 Build and Run images already exist in stack
-"some-stack" updated (no change)
+ClusterStack "some-stack" updated (no change)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})

--- a/pkg/commands/clusterstore/add.go
+++ b/pkg/commands/clusterstore/add.go
@@ -95,5 +95,5 @@ func update(store *v1alpha1.ClusterStore, buildpackages []string, factory *clust
 		return err
 	}
 
-	return ch.PrintChangeResult(storeUpdated, "ClusterStore Updated")
+	return ch.PrintChangeResult(storeUpdated, "ClusterStore %q updated", updatedStore.Name)
 }

--- a/pkg/commands/clusterstore/add_test.go
+++ b/pkg/commands/clusterstore/add_test.go
@@ -108,7 +108,11 @@ func testClusterStoreAddCommand(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			},
-			ExpectedOutput: "Adding Buildpackages...\n\tAdded Buildpackage\n\tAdded Buildpackage\nClusterStore Updated\n",
+			ExpectedOutput: `Adding Buildpackages...
+	Added Buildpackage
+	Added Buildpackage
+ClusterStore "some-store-name" updated
+`,
 		}.TestK8sAndKpack(t, cmdFunc)
 	})
 
@@ -127,7 +131,7 @@ func testClusterStoreAddCommand(t *testing.T, when spec.G, it spec.S) {
 			ExpectErr: false,
 			ExpectedOutput: `Adding Buildpackages...
 	Buildpackage already exists in the store
-ClusterStore Updated (no change)
+ClusterStore "some-store-name" updated (no change)
 `,
 		}.TestK8sAndKpack(t, cmdFunc)
 	})
@@ -366,7 +370,7 @@ status: {}
 				ExpectedOutput: `Adding Buildpackages... (dry run)
 	Added Buildpackage
 	Added Buildpackage
-ClusterStore Updated (dry run)
+ClusterStore "some-store-name" updated (dry run)
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -388,7 +392,7 @@ ClusterStore Updated (dry run)
 					ExpectErr: false,
 					ExpectedOutput: `Adding Buildpackages... (dry run)
 	Buildpackage already exists in the store
-ClusterStore Updated (no change)
+ClusterStore "some-store-name" updated (no change)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})

--- a/pkg/commands/clusterstore/create.go
+++ b/pkg/commands/clusterstore/create.go
@@ -86,5 +86,5 @@ func create(name string, buildpackages []string, factory *clusterstore.Factory, 
 		return err
 	}
 
-	return ch.PrintResult("%q created", newStore.Name)
+	return ch.PrintResult("ClusterStore %q created", newStore.Name)
 }

--- a/pkg/commands/clusterstore/create_test.go
+++ b/pkg/commands/clusterstore/create_test.go
@@ -89,7 +89,9 @@ func testClusterStoreCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--registry-ca-cert-path", "some-cert-path",
 				"--registry-verify-certs",
 			},
-			ExpectedOutput: "Creating ClusterStore...\n\"test-store\" created\n",
+			ExpectedOutput: `Creating ClusterStore...
+ClusterStore "test-store" created
+`,
 			ExpectCreates: []runtime.Object{
 				expectedStore,
 			},
@@ -239,7 +241,7 @@ status: {}
 					"--dry-run",
 				},
 				ExpectedOutput: `Creating ClusterStore... (dry run)
-"test-store" created (dry run)
+ClusterStore "test-store" created (dry run)
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})

--- a/pkg/commands/clusterstore/delete.go
+++ b/pkg/commands/clusterstore/delete.go
@@ -72,6 +72,6 @@ func deleteStore(cmd *cobra.Command, cs k8s.ClientSet, storeName string) error {
 		return err
 	}
 
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "\"%s\" store deleted\n", storeName)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "ClusterStore %q store deleted\n", storeName)
 	return err
 }

--- a/pkg/commands/clusterstore/delete_test.go
+++ b/pkg/commands/clusterstore/delete_test.go
@@ -66,9 +66,10 @@ func testClusterStoreDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 					Objects: []runtime.Object{
 						store,
 					},
-					Args:           []string{storeName},
-					ExpectErr:      false,
-					ExpectedOutput: fmt.Sprintf("%q store deleted\n", storeName),
+					Args:      []string{storeName},
+					ExpectErr: false,
+					ExpectedOutput: `ClusterStore "some-store-name" store deleted
+`,
 					ExpectDeletes: []clientgotesting.DeleteActionImpl{
 						{
 							Name: storeName,
@@ -162,9 +163,10 @@ func testClusterStoreDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 					Objects: []runtime.Object{
 						store,
 					},
-					Args:           []string{storeName, "-f"},
-					ExpectErr:      false,
-					ExpectedOutput: fmt.Sprintf("%q store deleted\n", storeName),
+					Args:      []string{storeName, "-f"},
+					ExpectErr: false,
+					ExpectedOutput: `ClusterStore "some-store-name" store deleted
+`,
 					ExpectDeletes: []clientgotesting.DeleteActionImpl{
 						{
 							Name: storeName,

--- a/pkg/commands/clusterstore/remove.go
+++ b/pkg/commands/clusterstore/remove.go
@@ -76,7 +76,7 @@ kp clusterstore remove my-store -b my-registry.com/my-buildpackage/buildpacks_ht
 				return err
 			}
 
-			return ch.Printlnf("ClusterStore Updated")
+			return ch.Printlnf("ClusterStore %q updated", store.Name)
 		},
 	}
 	cmd.Flags().StringArrayVarP(&buildpackages, "buildpackage", "b", []string{}, "buildpackage to remove")

--- a/pkg/commands/clusterstore/remove_test.go
+++ b/pkg/commands/clusterstore/remove_test.go
@@ -74,7 +74,9 @@ func testClusterStoreRemoveCommand(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			},
-			ExpectedOutput: "Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore\nClusterStore Updated\n",
+			ExpectedOutput: `Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
+ClusterStore "some-store" updated
+`,
 		}.TestKpack(t, cmdFunc)
 	})
 
@@ -99,7 +101,10 @@ func testClusterStoreRemoveCommand(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			},
-			ExpectedOutput: "Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore\nRemoving buildpackage some/imageinStore2@sha256:1232alreadyInStore\nClusterStore Updated\n",
+			ExpectedOutput: `Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
+Removing buildpackage some/imageinStore2@sha256:1232alreadyInStore
+ClusterStore "some-store" updated
+`,
 		}.TestKpack(t, cmdFunc)
 	})
 

--- a/pkg/commands/clusterstore/save_test.go
+++ b/pkg/commands/clusterstore/save_test.go
@@ -92,7 +92,9 @@ func testClusterStoreSaveCommand(t *testing.T, when spec.G, it spec.S) {
 					"--registry-ca-cert-path", "some-cert-path",
 					"--registry-verify-certs",
 				},
-				ExpectedOutput: "Creating ClusterStore...\n\"test-store\" created\n",
+				ExpectedOutput: `Creating ClusterStore...
+ClusterStore "test-store" created
+`,
 				ExpectCreates: []runtime.Object{
 					expectedStore,
 				},
@@ -242,7 +244,7 @@ status: {}
 						"--dry-run",
 					},
 					ExpectedOutput: `Creating ClusterStore... (dry run)
-"test-store" created (dry run)
+ClusterStore "test-store" created (dry run)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -318,7 +320,7 @@ status: {}
 				},
 				ExpectedOutput: `Adding Buildpackages...
 	Added Buildpackage
-ClusterStore Updated
+ClusterStore "test-store" updated
 `,
 			}.TestK8sAndKpack(t, cmdFunc)
 		})
@@ -495,7 +497,7 @@ status: {}
 					},
 					ExpectedOutput: `Adding Buildpackages... (dry run)
 	Added Buildpackage
-ClusterStore Updated (dry run)
+ClusterStore "test-store" updated (dry run)
 `,
 				}.TestK8sAndKpack(t, cmdFunc)
 			})
@@ -516,7 +518,7 @@ ClusterStore Updated (dry run)
 						},
 						ExpectedOutput: `Adding Buildpackages... (dry run)
 	Buildpackage already exists in the store
-ClusterStore Updated (no change)
+ClusterStore "test-store" updated (no change)
 `,
 					}.TestK8sAndKpack(t, cmdFunc)
 				})

--- a/pkg/commands/image/create.go
+++ b/pkg/commands/image/create.go
@@ -121,5 +121,5 @@ func create(name, tag string, factory *image.Factory, ch *commands.CommandHelper
 		return nil, err
 	}
 
-	return img, ch.PrintResult("%q created", img.Name)
+	return img, ch.PrintResult("Image %q created", img.Name)
 }

--- a/pkg/commands/image/create_test.go
+++ b/pkg/commands/image/create_test.go
@@ -105,7 +105,8 @@ func testImageCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						"--registry-verify-certs",
 						"--wait",
 					},
-					ExpectedOutput: "\"some-image\" created\n",
+					ExpectedOutput: `Image "some-image" created
+`,
 					ExpectCreates: []runtime.Object{
 						expectedImage,
 					},
@@ -184,7 +185,8 @@ func testImageCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						"--sub-path", "some-sub-path",
 						"--env", "some-key=some-val",
 					},
-					ExpectedOutput: "\"some-image\" created\n",
+					ExpectedOutput: `Image "some-image" created
+`,
 					ExpectCreates: []runtime.Object{
 						expectedImage,
 					},
@@ -258,7 +260,8 @@ func testImageCreateCommand(t *testing.T, when spec.G, it spec.S) {
 					"--sub-path", "some-sub-path",
 					"--env", "some-key=some-val",
 				},
-				ExpectedOutput: "\"some-image\" created\n",
+				ExpectedOutput: `Image "some-image" created
+`,
 				ExpectCreates: []runtime.Object{
 					expectedImage,
 				},
@@ -306,7 +309,8 @@ func testImageCreateCommand(t *testing.T, when spec.G, it spec.S) {
 					"--blob", "some-blob",
 					"--builder", "some-builder",
 				},
-				ExpectedOutput: "\"some-image\" created\n",
+				ExpectedOutput: `Image "some-image" created
+`,
 				ExpectCreates: []runtime.Object{
 					expectedImage,
 				},
@@ -353,7 +357,8 @@ func testImageCreateCommand(t *testing.T, when spec.G, it spec.S) {
 					"--blob", "some-blob",
 					"--cluster-builder", "some-builder",
 				},
-				ExpectedOutput: "\"some-image\" created\n",
+				ExpectedOutput: `Image "some-image" created
+`,
 				ExpectCreates: []runtime.Object{
 					expectedImage,
 				},
@@ -555,7 +560,7 @@ status: {}
 						"--dry-run",
 						"--wait",
 					},
-					ExpectedOutput: `"some-image" created (dry run)
+					ExpectedOutput: `Image "some-image" created (dry run)
 `,
 				}.TestKpack(t, cmdFunc)
 				assert.Len(t, fakeImageWaiter.Calls, 0)

--- a/pkg/commands/image/delete.go
+++ b/pkg/commands/image/delete.go
@@ -37,7 +37,7 @@ namespace defaults to the kubernetes current-context namespace.`,
 				return err
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "\"%s\" deleted\n", args[0])
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Image %q deleted\n", args[0])
 			return err
 		},
 		SilenceUsage: true,

--- a/pkg/commands/image/delete_test.go
+++ b/pkg/commands/image/delete_test.go
@@ -43,8 +43,9 @@ func testImageDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 					Objects: []runtime.Object{
 						image,
 					},
-					Args:           []string{"some-image", "-n", "some-namespace"},
-					ExpectedOutput: "\"some-image\" deleted\n",
+					Args: []string{"some-image", "-n", "some-namespace"},
+					ExpectedOutput: `Image "some-image" deleted
+`,
 					ExpectDeletes: []clientgotesting.DeleteActionImpl{
 						{
 							ActionImpl: clientgotesting.ActionImpl{
@@ -90,8 +91,9 @@ func testImageDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 					Objects: []runtime.Object{
 						image,
 					},
-					Args:           []string{"some-image"},
-					ExpectedOutput: "\"some-image\" deleted\n",
+					Args: []string{"some-image"},
+					ExpectedOutput: `Image "some-image" deleted
+`,
 					ExpectDeletes: []clientgotesting.DeleteActionImpl{
 						{
 							ActionImpl: clientgotesting.ActionImpl{

--- a/pkg/commands/image/patch.go
+++ b/pkg/commands/image/patch.go
@@ -132,5 +132,5 @@ func patch(img *v1alpha1.Image, factory *image.Factory, ch *commands.CommandHelp
 		return hasPatch, nil, err
 	}
 
-	return hasPatch, patchedImage, ch.PrintChangeResult(hasPatch, fmt.Sprintf("%q patched", img.Name))
+	return hasPatch, patchedImage, ch.PrintChangeResult(hasPatch, fmt.Sprintf("Image %q patched", img.Name))
 }

--- a/pkg/commands/image/patch_test.go
+++ b/pkg/commands/image/patch_test.go
@@ -88,7 +88,7 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 				Args: []string{
 					"some-image",
 				},
-				ExpectedOutput: `"some-image" patched (no change)
+				ExpectedOutput: `Image "some-image" patched (no change)
 `,
 			}.TestKpack(t, cmdFunc)
 			assert.Len(t, fakeImageWaiter.Calls, 0)
@@ -106,7 +106,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 						"some-image",
 						"--sub-path", "",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"source":{"subPath":null}}}`,
 					},
@@ -123,7 +124,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 						"some-image",
 						"--sub-path", "a-new-path",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"source":{"subPath":"a-new-path"}}}`,
 					},
@@ -141,7 +143,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 					"some-image",
 					"--blob", "some-blob",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"source":{"blob":{"url":"some-blob"},"git":null}}}`,
 				},
@@ -158,7 +161,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 					"some-image",
 					"--git-revision", "some-new-revision",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"source":{"git":{"revision":"some-new-revision"}}}}`,
 				},
@@ -181,7 +185,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 					"some-image",
 					"--git", "some-new-git-url",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"source":{"blob":null,"git":{"revision":"master","url":"some-new-git-url"}}}}`,
 				},
@@ -201,7 +206,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 					"some-image",
 					"--builder", "some-builder",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"builder":{"kind":"Builder","name":"some-builder","namespace":"some-default-namespace"}}}`,
 				},
@@ -220,7 +226,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 					"some-image",
 					"-d", "key2",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"build":{"env":[{"name":"key1","value":"value1"}]}}}`,
 				},
@@ -237,7 +244,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 					"some-image",
 					"-e", "key1=some-other-value",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"build":{"env":[{"name":"key1","value":"some-other-value"},{"name":"key2","value":"value2"}]}}}`,
 				},
@@ -254,7 +262,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 					"some-image",
 					"-e", "key3=value3",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"build":{"env":[{"name":"key1","value":"value1"},{"name":"key2","value":"value2"},{"name":"key3","value":"value3"}]}}}`,
 				},
@@ -273,7 +282,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 				"some-image",
 				"--cache-size", "3G",
 			},
-			ExpectedOutput: "\"some-image\" patched\n",
+			ExpectedOutput: `Image "some-image" patched
+`,
 			ExpectPatches: []string{
 				`{"spec":{"cacheSize":"3G"}}`,
 			},
@@ -293,7 +303,8 @@ func testImagePatchCommand(t *testing.T, when spec.G, it spec.S) {
 				"--registry-verify-certs",
 				"--wait",
 			},
-			ExpectedOutput: "\"some-image\" patched\n",
+			ExpectedOutput: `Image "some-image" patched
+`,
 			ExpectPatches: []string{
 				`{"spec":{"source":{"git":{"revision":"some-new-revision"}}}}`,
 			},
@@ -461,7 +472,7 @@ status: {}
 					"--dry-run",
 					"--wait",
 				},
-				ExpectedOutput: `"some-image" patched (dry run)
+				ExpectedOutput: `Image "some-image" patched (dry run)
 `,
 			}.TestKpack(t, cmdFunc)
 			assert.Len(t, fakeImageWaiter.Calls, 0)
@@ -477,7 +488,7 @@ status: {}
 						"some-image",
 						"--dry-run",
 					},
-					ExpectedOutput: `"some-image" patched (no change)
+					ExpectedOutput: `Image "some-image" patched (no change)
 `,
 				}.TestKpack(t, cmdFunc)
 			})

--- a/pkg/commands/image/save_test.go
+++ b/pkg/commands/image/save_test.go
@@ -106,7 +106,8 @@ func testImageSaveCommand(t *testing.T, when spec.G, it spec.S) {
 							"--registry-verify-certs",
 							"--wait",
 						},
-						ExpectedOutput: "\"some-image\" created\n",
+						ExpectedOutput: `Image "some-image" created
+`,
 						ExpectCreates: []runtime.Object{
 							expectedImage,
 						},
@@ -130,7 +131,8 @@ func testImageSaveCommand(t *testing.T, when spec.G, it spec.S) {
 							"--cache-size", "2G",
 							"-n", namespace,
 						},
-						ExpectedOutput: "\"some-image\" created\n",
+						ExpectedOutput: `Image "some-image" created
+`,
 						ExpectCreates: []runtime.Object{
 							expectedImage,
 						},
@@ -206,7 +208,8 @@ func testImageSaveCommand(t *testing.T, when spec.G, it spec.S) {
 							"--sub-path", "some-sub-path",
 							"--env", "some-key=some-val",
 						},
-						ExpectedOutput: "\"some-image\" created\n",
+						ExpectedOutput: `Image "some-image" created
+`,
 						ExpectCreates: []runtime.Object{
 							expectedImage,
 						},
@@ -280,7 +283,8 @@ func testImageSaveCommand(t *testing.T, when spec.G, it spec.S) {
 						"--sub-path", "some-sub-path",
 						"--env", "some-key=some-val",
 					},
-					ExpectedOutput: "\"some-image\" created\n",
+					ExpectedOutput: `Image "some-image" created
+`,
 					ExpectCreates: []runtime.Object{
 						expectedImage,
 					},
@@ -328,7 +332,8 @@ func testImageSaveCommand(t *testing.T, when spec.G, it spec.S) {
 						"--blob", "some-blob",
 						"--builder", "some-builder",
 					},
-					ExpectedOutput: "\"some-image\" created\n",
+					ExpectedOutput: `Image "some-image" created
+`,
 					ExpectCreates: []runtime.Object{
 						expectedImage,
 					},
@@ -375,7 +380,8 @@ func testImageSaveCommand(t *testing.T, when spec.G, it spec.S) {
 						"--blob", "some-blob",
 						"--cluster-builder", "some-builder",
 					},
-					ExpectedOutput: "\"some-image\" created\n",
+					ExpectedOutput: `Image "some-image" created
+`,
 					ExpectCreates: []runtime.Object{
 						expectedImage,
 					},
@@ -587,7 +593,7 @@ status: {}
 							"--dry-run",
 							"--wait",
 						},
-						ExpectedOutput: `"some-image" created (dry run)
+						ExpectedOutput: `Image "some-image" created (dry run)
 `,
 					}.TestKpack(t, cmdFunc)
 					assert.Len(t, fakeImageWaiter.Calls, 0)
@@ -704,7 +710,7 @@ status: {}
 					Args: []string{
 						"some-image",
 					},
-					ExpectedOutput: `"some-image" patched (no change)
+					ExpectedOutput: `Image "some-image" patched (no change)
 `,
 				}.TestKpack(t, cmdFunc)
 				assert.Len(t, fakeImageWaiter.Calls, 0)
@@ -722,7 +728,8 @@ status: {}
 							"some-image",
 							"--sub-path", "",
 						},
-						ExpectedOutput: "\"some-image\" patched\n",
+						ExpectedOutput: `Image "some-image" patched
+`,
 						ExpectPatches: []string{
 							`{"spec":{"source":{"subPath":null}}}`,
 						},
@@ -739,7 +746,8 @@ status: {}
 							"some-image",
 							"--sub-path", "a-new-path",
 						},
-						ExpectedOutput: "\"some-image\" patched\n",
+						ExpectedOutput: `Image "some-image" patched
+`,
 						ExpectPatches: []string{
 							`{"spec":{"source":{"subPath":"a-new-path"}}}`,
 						},
@@ -757,7 +765,8 @@ status: {}
 						"some-image",
 						"--blob", "some-blob",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"source":{"blob":{"url":"some-blob"},"git":null}}}`,
 					},
@@ -774,7 +783,8 @@ status: {}
 						"some-image",
 						"--git-revision", "some-new-revision",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"source":{"git":{"revision":"some-new-revision"}}}}`,
 					},
@@ -797,7 +807,8 @@ status: {}
 						"some-image",
 						"--git", "some-new-git-url",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"source":{"blob":null,"git":{"revision":"master","url":"some-new-git-url"}}}}`,
 					},
@@ -817,7 +828,8 @@ status: {}
 						"some-image",
 						"--builder", "some-builder",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"builder":{"kind":"Builder","name":"some-builder","namespace":"some-default-namespace"}}}`,
 					},
@@ -836,7 +848,8 @@ status: {}
 						"some-image",
 						"-d", "key2",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"build":{"env":[{"name":"key1","value":"value1"}]}}}`,
 					},
@@ -853,7 +866,8 @@ status: {}
 						"some-image",
 						"-e", "key1=some-other-value",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"build":{"env":[{"name":"key1","value":"some-other-value"},{"name":"key2","value":"value2"}]}}}`,
 					},
@@ -870,7 +884,8 @@ status: {}
 						"some-image",
 						"-e", "key3=value3",
 					},
-					ExpectedOutput: "\"some-image\" patched\n",
+					ExpectedOutput: `Image "some-image" patched
+`,
 					ExpectPatches: []string{
 						`{"spec":{"build":{"env":[{"name":"key1","value":"value1"},{"name":"key2","value":"value2"},{"name":"key3","value":"value3"}]}}}`,
 					},
@@ -889,7 +904,8 @@ status: {}
 					"some-image",
 					"--cache-size", "3G",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"cacheSize":"3G"}}`,
 				},
@@ -907,7 +923,8 @@ status: {}
 					"--git-revision", "some-new-revision",
 					"--wait",
 				},
-				ExpectedOutput: "\"some-image\" patched\n",
+				ExpectedOutput: `Image "some-image" patched
+`,
 				ExpectPatches: []string{
 					`{"spec":{"source":{"git":{"revision":"some-new-revision"}}}}`,
 				},
@@ -1075,7 +1092,7 @@ status: {}
 						"--dry-run",
 						"--wait",
 					},
-					ExpectedOutput: `"some-image" patched (dry run)
+					ExpectedOutput: `Image "some-image" patched (dry run)
 `,
 				}.TestKpack(t, cmdFunc)
 				assert.Len(t, fakeImageWaiter.Calls, 0)
@@ -1091,7 +1108,7 @@ status: {}
 							"some-image",
 							"--dry-run",
 						},
-						ExpectedOutput: `"some-image" patched (no change)
+						ExpectedOutput: `Image "some-image" patched (no change)
 `,
 					}.TestKpack(t, cmdFunc)
 				})

--- a/pkg/commands/image/trigger.go
+++ b/pkg/commands/image/trigger.go
@@ -58,7 +58,7 @@ The namespace defaults to the kubernetes current-context namespace.`,
 					return err
 				}
 
-				_, err = fmt.Fprintf(cmd.OutOrStderr(), "\"%s\" triggered\n", args[0])
+				_, err = fmt.Fprintf(cmd.OutOrStderr(), "Triggered build for Image %q\n", args[0])
 				return err
 			}
 		},

--- a/pkg/commands/image/trigger_test.go
+++ b/pkg/commands/image/trigger_test.go
@@ -42,7 +42,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "\"some-image\" triggered\n", out.String())
+				require.Equal(t, "Triggered build for Image \"some-image\"\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)
@@ -83,7 +83,7 @@ func testImageTrigger(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				require.NoError(t, err)
-				require.Equal(t, "\"some-image\" triggered\n", out.String())
+				require.Equal(t, "Triggered build for Image \"some-image\"\n", out.String())
 
 				actions, err := testhelpers.ActionRecorderList{clientSet}.ActionsByVerb()
 				require.NoError(t, err)

--- a/pkg/commands/secret/create.go
+++ b/pkg/commands/secret/create.go
@@ -115,7 +115,7 @@ kp secret create my-git-cred --git-url https://github.com --git-user my-git-user
 				return err
 			}
 
-			return ch.PrintResult("%q created", secret.Name)
+			return ch.PrintResult("Secret %q created", secret.Name)
 		},
 	}
 

--- a/pkg/commands/secret/create_test.go
+++ b/pkg/commands/secret/create_test.go
@@ -102,7 +102,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--dockerhub", dockerhubId, "-n", namespace},
-					ExpectedOutput: `"my-docker-cred" created
+					ExpectedOutput: `Secret "my-docker-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -160,7 +160,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser, "-n", namespace},
-					ExpectedOutput: `"my-registry-cred" created
+					ExpectedOutput: `Secret "my-registry-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -216,7 +216,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--gcr", gcrServiceAccountFile, "-n", namespace},
-					ExpectedOutput: `"my-gcr-cred" created
+					ExpectedOutput: `Secret "my-gcr-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -272,7 +272,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-ssh-key", gitSshFile, "-n", namespace},
-					ExpectedOutput: `"my-git-ssh-cred" created
+					ExpectedOutput: `Secret "my-git-ssh-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -330,7 +330,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultNamespacedServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-user", gitUser, "-n", namespace},
-					ExpectedOutput: `"my-git-basic-cred" created
+					ExpectedOutput: `Secret "my-git-basic-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -389,7 +389,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--dockerhub", dockerhubId},
-					ExpectedOutput: `"my-docker-cred" created
+					ExpectedOutput: `Secret "my-docker-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -447,7 +447,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--registry", registry, "--registry-user", registryUser},
-					ExpectedOutput: `"my-registry-cred" created
+					ExpectedOutput: `Secret "my-registry-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -503,7 +503,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--gcr", gcrServiceAccountFile},
-					ExpectedOutput: `"my-gcr-cred" created
+					ExpectedOutput: `Secret "my-gcr-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedDockerSecret,
@@ -559,7 +559,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-ssh-key", gitSshFile},
-					ExpectedOutput: `"my-git-ssh-cred" created
+					ExpectedOutput: `Secret "my-git-ssh-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -617,7 +617,7 @@ func testSecretCreateCommand(t *testing.T, when spec.G, it spec.S) {
 						defaultServiceAccount,
 					},
 					Args: []string{secretName, "--git-url", gitRepo, "--git-user", gitUser},
-					ExpectedOutput: `"my-git-basic-cred" created
+					ExpectedOutput: `Secret "my-git-basic-cred" created
 `,
 					ExpectCreates: []runtime.Object{
 						expectedGitSecret,
@@ -788,7 +788,7 @@ secrets:
 					"--dockerhub", "my-dockerhub-id",
 					"--dry-run",
 				},
-				ExpectedOutput: `"my-docker-cred" created (dry run)
+				ExpectedOutput: `Secret "my-docker-cred" created (dry run)
 `,
 			}.TestK8s(t, cmdFunc)
 		})

--- a/pkg/commands/secret/delete.go
+++ b/pkg/commands/secret/delete.go
@@ -54,7 +54,7 @@ The namespace defaults to the kubernetes current-context namespace.`,
 				return err
 			}
 
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "\"%s\" deleted\n", args[0])
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Secret %q deleted\n", args[0])
 			return err
 		},
 	}

--- a/pkg/commands/secret/delete_test.go
+++ b/pkg/commands/secret/delete_test.go
@@ -78,8 +78,9 @@ func testSecretDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 							secretOne,
 							serviceAccount,
 						},
-						Args:           []string{secretName},
-						ExpectedOutput: "\"some-secret\" deleted\n",
+						Args: []string{secretName},
+						ExpectedOutput: `Secret "some-secret" deleted
+`,
 						ExpectUpdates: []clientgotesting.UpdateActionImpl{
 							{
 								Object: expectedServiceAccount,
@@ -172,8 +173,9 @@ func testSecretDeleteCommand(t *testing.T, when spec.G, it spec.S) {
 							secretOne,
 							serviceAccount,
 						},
-						Args:           []string{secretName, "-n", namespace},
-						ExpectedOutput: "\"some-secret\" deleted\n",
+						Args: []string{secretName, "-n", namespace},
+						ExpectedOutput: `Secret "some-secret" deleted
+`,
 						ExpectUpdates: []clientgotesting.UpdateActionImpl{
 							{
 								Object: expectedServiceAccount,

--- a/pkg/commands/secret/list.go
+++ b/pkg/commands/secret/list.go
@@ -40,7 +40,7 @@ The namespace defaults to the kubernetes current-context namespace.`,
 			}
 
 			if len(serviceAccount.Secrets) == 0 && len(serviceAccount.ImagePullSecrets) == 0 {
-				return errors.Errorf("no secrets found in \"%s\" namespace", cs.Namespace)
+				return errors.Errorf("no secrets found in %q namespace", cs.Namespace)
 			} else {
 				return displaySecretsTable(cmd, serviceAccount)
 			}


### PR DESCRIPTION
Format: `<resource-type-pascal-case> "<resource-name>" <action-lower-case>`
Example: `ClusterStore "my-store" created`

Where:
- resources types are Secret, Image, ClusterStore, ClusterStack,
ClusterBuilder, Builder
- actions are created, patched, updated, deleted

This commit bases of an older PR https://github.com/vmware-tanzu/kpack-cli/pull/97 with the commit https://github.com/vmware-tanzu/kpack-cli/commit/da692ecc606ee70a96e9742f5e3d5dff18b77e2c
Commit for this PR is limited to  https://github.com/vmware-tanzu/kpack-cli/commit/afbddf3718b558f5f7dc406aca0dfba56fb31aef