### PR TITLE
add `--buildpack` flag to `kp builder create` and `kp clusterbuilder create`

### DIFF
--- a/pkg/builder/helpers.go
+++ b/pkg/builder/helpers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 
 	"github.com/ghodss/yaml"
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
@@ -35,4 +36,27 @@ func ReadOrder(path string) ([]v1alpha1.OrderEntry, error) {
 
 	var order []v1alpha1.OrderEntry
 	return order, yaml.Unmarshal(buf, &order)
+}
+
+func CreateOrder(buildpacks []string) []v1alpha1.OrderEntry {
+	group := make([]v1alpha1.BuildpackRef, 0)
+
+	// this regular expression splits out buildpack id and version
+	var re = regexp.MustCompile(`(?m)^([^@]+)[@]?(.*)`)
+
+	for _, buildpack := range buildpacks {
+		submatch := re.FindStringSubmatch(buildpack)
+
+		id := submatch[1]
+		version := submatch[2]
+
+		group = append(group, v1alpha1.BuildpackRef{
+			BuildpackInfo: v1alpha1.BuildpackInfo{
+				Id: id,
+				Version: version,
+			},
+		})
+	}
+
+	return []v1alpha1.OrderEntry{{Group: group}}
 }

--- a/pkg/commands/builder/create_test.go
+++ b/pkg/commands/builder/create_test.go
@@ -304,6 +304,12 @@ status:
 						},
 						{
 							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id: "org.cloudfoundry.nodejs",
+								Version: "1",
+							},
+						},
+						{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
 								Id: "org.cloudfoundry.ruby",
 								Version: "1.2.3",
 							},
@@ -311,7 +317,7 @@ status:
 					},
 				},
 			}
-			expectedBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"Builder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","namespace":"some-namespace","creationTimestamp":null},"spec":{"tag":"some-registry.com/test-builder","stack":{"kind":"ClusterStack","name":"some-stack"},"store":{"kind":"ClusterStore","name":"some-store"},"order":[{"group":[{"id":"org.cloudfoundry.go"},{"id":"org.cloudfoundry.ruby","version":"1.2.3"}]}],"serviceAccount":"default"},"status":{"stack":{}}}`
+			expectedBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"Builder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","namespace":"some-namespace","creationTimestamp":null},"spec":{"tag":"some-registry.com/test-builder","stack":{"kind":"ClusterStack","name":"some-stack"},"store":{"kind":"ClusterStore","name":"some-store"},"order":[{"group":[{"id":"org.cloudfoundry.go"},{"id":"org.cloudfoundry.nodejs","version":"1"},{"id":"org.cloudfoundry.ruby","version":"1.2.3"}]}],"serviceAccount":"default"},"status":{"stack":{}}}`
 
 			testhelpers.CommandTest{
 				Args: []string{
@@ -319,7 +325,7 @@ status:
 					"--tag", expectedBuilder.Spec.Tag,
 					"--stack", expectedBuilder.Spec.Stack.Name,
 					"--store", expectedBuilder.Spec.Store.Name,
-					"--buildpack", "org.cloudfoundry.go",
+					"--buildpack", "org.cloudfoundry.go,org.cloudfoundry.nodejs@1",
 					"--buildpack", "org.cloudfoundry.ruby@1.2.3",
 					"-n", expectedBuilder.Namespace,
 				},

--- a/pkg/commands/builder/create_test.go
+++ b/pkg/commands/builder/create_test.go
@@ -290,4 +290,64 @@ status:
 			})
 		})
 	})
+
+	when("buildpack flag is used", func() {
+		it("creates a builder using the buildpack flag", func() {
+
+			expectedBuilder.Spec.Order = []v1alpha1.OrderEntry{
+				{
+					Group: []v1alpha1.BuildpackRef{
+						{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id: "org.cloudfoundry.go",
+							},
+						},
+						{
+							BuildpackInfo: v1alpha1.BuildpackInfo{
+								Id: "org.cloudfoundry.ruby",
+								Version: "1.2.3",
+							},
+						},
+					},
+				},
+			}
+			expectedBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"Builder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","namespace":"some-namespace","creationTimestamp":null},"spec":{"tag":"some-registry.com/test-builder","stack":{"kind":"ClusterStack","name":"some-stack"},"store":{"kind":"ClusterStore","name":"some-store"},"order":[{"group":[{"id":"org.cloudfoundry.go"},{"id":"org.cloudfoundry.ruby","version":"1.2.3"}]}],"serviceAccount":"default"},"status":{"stack":{}}}`
+
+			testhelpers.CommandTest{
+				Args: []string{
+					expectedBuilder.Name,
+					"--tag", expectedBuilder.Spec.Tag,
+					"--stack", expectedBuilder.Spec.Stack.Name,
+					"--store", expectedBuilder.Spec.Store.Name,
+					"--buildpack", "org.cloudfoundry.go",
+					"--buildpack", "org.cloudfoundry.ruby@1.2.3",
+					"-n", expectedBuilder.Namespace,
+				},
+				ExpectedOutput: `Builder "test-builder" created
+`,
+				ExpectCreates: []runtime.Object{
+					expectedBuilder,
+				},
+			}.TestKpack(t, cmdFunc)
+		})
+
+		when("buildpack and order flags are used together", func() {
+			it("returns an error", func() {
+				testhelpers.CommandTest{
+					Args: []string{
+						expectedBuilder.Name,
+						"--tag", expectedBuilder.Spec.Tag,
+						"--order", "./testdata/order.yaml",
+						"--buildpack", "some-buildpack-name",
+					},
+					ExpectErr: true,
+					ExpectedOutput: `Error: cannot use --order and --buildpack together
+`,
+				}.TestKpack(t, cmdFunc)
+			})
+		})
+	})
+
+
+
 }

--- a/pkg/commands/clusterbuilder/create.go
+++ b/pkg/commands/clusterbuilder/create.go
@@ -4,6 +4,7 @@
 package clusterbuilder
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/spf13/cobra"
@@ -65,15 +66,17 @@ kp cb create my-builder --tag my-registry.com/my-builder-tag --order /path/to/or
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", defaultStack, "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", defaultStore, "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack","b", []string{} , "list of buildpacks to use")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }
 
 type CommandFlags struct {
-	tag   string
-	stack string
-	store string
-	order string
+	tag        string
+	stack      string
+	store      string
+	order      string
+	buildpacks []string
 }
 
 func create(name string, flags CommandFlags, ch *commands.CommandHelper, cs k8s.ClientSet) error {
@@ -121,9 +124,19 @@ func create(name string, flags CommandFlags, ch *commands.CommandHelper, cs k8s.
 		},
 	}
 
-	cb.Spec.Order, err = builder.ReadOrder(flags.order)
-	if err != nil {
-		return err
+	if len(flags.buildpacks) > 0 && flags.order != "" {
+		return fmt.Errorf("cannot use --order and --buildpack together")
+	}
+
+	if len(flags.buildpacks) > 0 {
+		cb.Spec.Order = builder.CreateOrder(flags.buildpacks)
+	}
+
+	if flags.order != "" {
+		cb.Spec.Order, err = builder.ReadOrder(flags.order)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = k8s.SetLastAppliedCfg(cb)


### PR DESCRIPTION
- mutually exclusive with `--order`
- can specify multiple buildpacks separated by commas or by using the flag multiple times
- all buildpacks will be put in the same group
- can specify version of buildpack using `<id>@<version>`