### PR TITLE
Allow builder order to be set with flags on patch.go

### DIFF
--- a/pkg/commands/builder/create.go
+++ b/pkg/commands/builder/create.go
@@ -61,7 +61,7 @@ kp builder create my-builder --tag my-registry.com/my-builder-tag --order /path/
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", defaultStack, "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", defaultStore, "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
-	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack","b", []string{} , "list of buildpacks to use")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
 	commands.SetDryRunOutputFlags(cmd)
 	_ = cmd.MarkFlagRequired("tag")
 	return cmd

--- a/pkg/commands/builder/create.go
+++ b/pkg/commands/builder/create.go
@@ -61,7 +61,7 @@ kp builder create my-builder --tag my-registry.com/my-builder-tag --order /path/
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", defaultStack, "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", defaultStore, "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
-	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
 	commands.SetDryRunOutputFlags(cmd)
 	_ = cmd.MarkFlagRequired("tag")
 	return cmd

--- a/pkg/commands/builder/create.go
+++ b/pkg/commands/builder/create.go
@@ -33,9 +33,13 @@ func NewCreateCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 		Long: `Create a builder by providing command line arguments.
 The builder will be created only if it does not exist in the provided namespace.
 
+A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+
 The namespace defaults to the kubernetes current-context namespace.`,
 		Example: `kp builder create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml --stack tiny --store my-store
-kp builder create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml`,
+kp builder create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml
+kp builder create my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/builder/patch.go
+++ b/pkg/commands/builder/patch.go
@@ -22,10 +22,17 @@ func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:          "patch <name>",
-		Short:        "Patch an existing builder configuration",
-		Long:         ` `,
-		Example:      `kp builder patch my-builder`,
+		Use:   "patch <name>",
+		Short: "Patch an existing builder configuration",
+		Long: `Patch an existing builder configuration by providing command line arguments.
+
+A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+
+The namespace defaults to the kubernetes current-context namespace.`,
+		Example: `kp builder patch my-builder --order /path/to/order.yaml --stack tiny --store my-store
+kp builder patch my-builder --order /path/to/order.yaml
+kp builder patch my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/builder/patch.go
+++ b/pkg/commands/builder/patch.go
@@ -56,7 +56,7 @@ func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", "", "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
-	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }

--- a/pkg/commands/builder/patch.go
+++ b/pkg/commands/builder/patch.go
@@ -4,7 +4,8 @@
 package builder
 
 import (
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +13,7 @@ import (
 	"github.com/pivotal/build-service-cli/pkg/builder"
 	"github.com/pivotal/build-service-cli/pkg/commands"
 	"github.com/pivotal/build-service-cli/pkg/k8s"
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
@@ -54,6 +56,7 @@ func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", "", "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }
@@ -73,6 +76,10 @@ func patch(bldr *v1alpha1.Builder, flags CommandFlags, ch *commands.CommandHelpe
 		patchedBldr.Spec.Store.Name = flags.store
 	}
 
+	if len(flags.buildpacks) > 0 && flags.order != "" {
+		return fmt.Errorf("cannot use --order and --buildpack together")
+	}
+
 	if flags.order != "" {
 		orderEntries, err := builder.ReadOrder(flags.order)
 		if err != nil {
@@ -80,6 +87,10 @@ func patch(bldr *v1alpha1.Builder, flags CommandFlags, ch *commands.CommandHelpe
 		}
 
 		patchedBldr.Spec.Order = orderEntries
+	}
+
+	if len(flags.buildpacks) > 0 {
+		patchedBldr.Spec.Order = builder.CreateOrder(flags.buildpacks)
 	}
 
 	patch, err := k8s.CreatePatch(bldr, patchedBldr)

--- a/pkg/commands/builder/save.go
+++ b/pkg/commands/builder/save.go
@@ -23,13 +23,17 @@ func NewSaveCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 		Long: `Create or patch a builder by providing command line arguments.
 The builder will be created only if it does not exist in the provided namespace, otherwise it will be patched.
 
+A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+
 The --tag flag is required for a create but is immutable and will be ignored for a patch.
 
 No defaults will be assumed for patches.
 
 The namespace defaults to the kubernetes current-context namespace.`,
 		Example: `kp builder save my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml --stack tiny --store my-store
-kp builder save my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml`,
+kp builder save my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml
+kp builder save my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/builder/save.go
+++ b/pkg/commands/builder/save.go
@@ -74,6 +74,7 @@ kp builder save my-builder --tag my-registry.com/my-builder-tag --order /path/to
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", "", "stack resource to use (default \"default\" for a create)")
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use (default \"default\" for a create)")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }

--- a/pkg/commands/clusterbuilder/create.go
+++ b/pkg/commands/clusterbuilder/create.go
@@ -66,7 +66,7 @@ kp cb create my-builder --tag my-registry.com/my-builder-tag --order /path/to/or
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", defaultStack, "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", defaultStore, "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
-	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }

--- a/pkg/commands/clusterbuilder/create.go
+++ b/pkg/commands/clusterbuilder/create.go
@@ -36,13 +36,16 @@ func NewCreateCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 		Long: `Create a cluster builder by providing command line arguments.
 The cluster builder will be created only if it does not exist.
 
+A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+
 Tag when not specified, defaults to a combination of the canonical repository and specified builder name.
 The canonical repository is read from the "canonical.repository" key in the "kp-config" ConfigMap within "kpack" namespace.
 `,
 		Example: `kp cb create my-builder --order /path/to/order.yaml --stack tiny --store my-store
-kp cb create my-builder --order /path/to/order.yaml
+kp cb create my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1
 kp cb create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml --stack tiny --store my-store
-kp cb create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml`,
+kp cb create my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/clusterbuilder/create.go
+++ b/pkg/commands/clusterbuilder/create.go
@@ -66,7 +66,7 @@ kp cb create my-builder --tag my-registry.com/my-builder-tag --order /path/to/or
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", defaultStack, "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", defaultStore, "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
-	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack","b", []string{} , "list of buildpacks to use")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }

--- a/pkg/commands/clusterbuilder/patch.go
+++ b/pkg/commands/clusterbuilder/patch.go
@@ -22,10 +22,15 @@ func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:          "patch <name>",
-		Short:        "Patch an existing cluster builder configuration",
-		Long:         ` `,
-		Example:      `kp cb patch my-builder`,
+		Use:   "patch <name>",
+		Short: "Patch an existing cluster builder configuration",
+		Long: `Patch an existing clusterbuilder configuration by providing command line arguments.
+
+A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group.`,
+		Example: `kp cb patch my-builder --order /path/to/order.yaml --stack tiny --store my-store
+kp cb patch my-builder --order /path/to/order.yaml
+kp cb patch my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/clusterbuilder/patch.go
+++ b/pkg/commands/clusterbuilder/patch.go
@@ -54,7 +54,7 @@ func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", "", "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
-	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }

--- a/pkg/commands/clusterbuilder/patch.go
+++ b/pkg/commands/clusterbuilder/patch.go
@@ -4,7 +4,8 @@
 package clusterbuilder
 
 import (
-	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +13,7 @@ import (
 	"github.com/pivotal/build-service-cli/pkg/builder"
 	"github.com/pivotal/build-service-cli/pkg/commands"
 	"github.com/pivotal/build-service-cli/pkg/k8s"
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
 func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
@@ -52,6 +54,7 @@ func NewPatchCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", "", "stack resource to use")
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }
@@ -71,6 +74,10 @@ func patch(cb *v1alpha1.ClusterBuilder, flags CommandFlags, ch *commands.Command
 		patchedCb.Spec.Store.Name = flags.store
 	}
 
+	if len(flags.buildpacks) > 0 && flags.order != "" {
+		return fmt.Errorf("cannot use --order and --buildpack together")
+	}
+
 	if flags.order != "" {
 		orderEntries, err := builder.ReadOrder(flags.order)
 		if err != nil {
@@ -78,6 +85,10 @@ func patch(cb *v1alpha1.ClusterBuilder, flags CommandFlags, ch *commands.Command
 		}
 
 		patchedCb.Spec.Order = orderEntries
+	}
+
+	if len(flags.buildpacks) > 0 {
+		patchedCb.Spec.Order = builder.CreateOrder(flags.buildpacks)
 	}
 
 	patch, err := k8s.CreatePatch(cb, patchedCb)

--- a/pkg/commands/clusterbuilder/save.go
+++ b/pkg/commands/clusterbuilder/save.go
@@ -70,6 +70,7 @@ kp cb save my-builder --tag my-registry.com/my-builder-tag --order /path/to/orde
 	cmd.Flags().StringVarP(&flags.stack, "stack", "s", "", "stack resource to use (default \"default\" for a create)")
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use (default \"default\" for a create)")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
+	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
 	commands.SetDryRunOutputFlags(cmd)
 	return cmd
 }

--- a/pkg/commands/clusterbuilder/save.go
+++ b/pkg/commands/clusterbuilder/save.go
@@ -23,15 +23,18 @@ func NewSaveCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 		Long: `Create or patch a cluster builder by providing command line arguments.
 The cluster builder will be created only if it does not exist, otherwise it is patched.
 
+A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+
 Tag when not specified, defaults to a combination of the canonical repository and specified builder name.
 The canonical repository is read from the "canonical.repository" key in the "kp-config" ConfigMap within "kpack" namespace.
 
 No defaults will be assumed for patches.
 `,
 		Example: `kp cb save my-builder --order /path/to/order.yaml --stack tiny --store my-store
-kp cb save my-builder --order /path/to/order.yaml
+kp cb save my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1
 kp cb save my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml --stack tiny --store my-store
-kp cb save my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml`,
+kp cb save my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
- update help text to be more descriptive

`buildpack reference(s) to a buildpack in the form of either '<buildpack>@<version>' or '<buildpack>'`