### PR TITLE
readme: make kpack link a fully formed url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kp cli to interact with [kpack](github.com/pivotal/kpack)
+# kp cli to interact with [kpack](https://github.com/pivotal/kpack)
 
 ## Contributing
 


### PR DESCRIPTION
Hey folks!  

Quick fix - without an obvious indicator that it's a url, github will render it as a relative reference to a repository file.

thx!