### PR TITLE
Display builds across images in kp build list

### DIFF
--- a/docs/kp_build.md
+++ b/docs/kp_build.md
@@ -15,7 +15,7 @@ Build Commands
 ### SEE ALSO
 
 * [kp](kp.md)	 - 
-* [kp build list](kp_build_list.md)	 - List builds for an image
+* [kp build list](kp_build_list.md)	 - List builds
 * [kp build logs](kp_build_logs.md)	 - Tails logs for an image build
 * [kp build status](kp_build_status.md)	 - Display status for an image build
 

--- a/docs/kp_build_list.md
+++ b/docs/kp_build_list.md
@@ -1,20 +1,21 @@
 ## kp build list
 
-List builds for an image
+List builds
 
 ### Synopsis
 
-Prints a table of the most important information about builds for an image in the provided namespace.
+Prints a table of the most important information about builds in the provided namespace.
 
 The namespace defaults to the kubernetes current-context namespace.
 
 ```
-kp build list <image-name> [flags]
+kp build list [image-name] [flags]
 ```
 
 ### Examples
 
 ```
+kp build list
 kp build list my-image
 kp build list my-image -n my-namespace
 ```

--- a/pkg/build/helpers.go
+++ b/pkg/build/helpers.go
@@ -9,6 +9,12 @@ import (
 
 func Sort(builds []v1alpha1.Build) func(i int, j int) bool {
 	return func(i, j int) bool {
+		l1, _ := builds[i].ObjectMeta.Labels[v1alpha1.ImageLabel]
+		l2, _ := builds[j].ObjectMeta.Labels[v1alpha1.ImageLabel]
+		if l1 != l2 {
+			return l1 > l2
+		}
+
 		return builds[j].ObjectMeta.CreationTimestamp.After(builds[i].ObjectMeta.CreationTimestamp.Time)
 	}
 }

--- a/pkg/commands/args.go
+++ b/pkg/commands/args.go
@@ -14,3 +14,11 @@ func ExactArgsWithUsage(n int) cobra.PositionalArgs {
 		return nil
 	}
 }
+func OptionalArgsWithUsage(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 && len(args) != n {
+			return fmt.Errorf("accepts 0 or %d arg(s), received %d\n\n%s", n, len(args), cmd.UsageString())
+		}
+		return nil
+	}
+}

--- a/pkg/commands/args_test.go
+++ b/pkg/commands/args_test.go
@@ -29,3 +29,24 @@ Actual:
 %v`, expectedMsg, err)
 	}
 }
+
+func TestOptionalArgsWithUsage(t *testing.T) {
+	cmd := cobra.Command{
+		Args: commands.OptionalArgsWithUsage(1),
+	}
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "some usage")
+		return err
+	})
+
+	expectedMsg := "accepts 0 or 1 arg(s), received 2\n\nsome usage\n"
+	err := cmd.ValidateArgs([]string{"some-arg-1", "some-arg-2"})
+
+	if err == nil || err.Error() != expectedMsg {
+		t.Errorf(`Did not return expected usage error from using wrong number of args.
+Expected:
+%v
+Actual:
+%v`, expectedMsg, err)
+	}
+}

--- a/pkg/commands/build/list.go
+++ b/pkg/commands/build/list.go
@@ -22,14 +22,14 @@ func NewListCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "list <image-name>",
-		Short: "List builds for an image",
-		Long: `Prints a table of the most important information about builds for an image in the provided namespace.
+		Use:   "list [image-name]",
+		Short: "List builds",
+		Long: `Prints a table of the most important information about builds in the provided namespace.
 
 The namespace defaults to the kubernetes current-context namespace.`,
 
-		Example:      "kp build list my-image\nkp build list my-image -n my-namespace",
-		Args:         commands.ExactArgsWithUsage(1),
+		Example:      "kp build list\nkp build list my-image\nkp build list my-image -n my-namespace",
+		Args:         commands.OptionalArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cs, err := clientSetProvider.GetClientSet(namespace)
@@ -37,9 +37,13 @@ The namespace defaults to the kubernetes current-context namespace.`,
 				return err
 			}
 
-			buildList, err := cs.KpackClient.KpackV1alpha1().Builds(cs.Namespace).List(metav1.ListOptions{
-				LabelSelector: v1alpha1.ImageLabel + "=" + args[0],
-			})
+			opts := metav1.ListOptions{}
+
+			if len(args) > 0 {
+				opts.LabelSelector = v1alpha1.ImageLabel + "=" + args[0]
+			}
+
+			buildList, err := cs.KpackClient.KpackV1alpha1().Builds(cs.Namespace).List(opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/commands/build/list_test.go
+++ b/pkg/commands/build/list_test.go
@@ -22,10 +22,11 @@ func testBuildListCommand(t *testing.T, when spec.G, it spec.S) {
 	const (
 		image            = "test-image"
 		defaultNamespace = "some-default-namespace"
-		expectedOutput   = `BUILD    STATUS      IMAGE                   REASON
-1        SUCCESS     repo.com/image-1:tag    CONFIG
-2        FAILURE     repo.com/image-2:tag    COMMIT+
-3        BUILDING    repo.com/image-3:tag    TRIGGER
+		expectedOutput   = `BUILD    STATUS      IMAGE                         REASON
+1        SUCCESS     repo.com/image-1:tag          CONFIG
+2        FAILURE     repo.com/image-2:tag          COMMIT+
+3        BUILDING    repo.com/image-3:tag          TRIGGER
+1        BUILDING    repo.com/other-image-1:tag    UNKNOWN
 
 `
 	)
@@ -41,7 +42,7 @@ func testBuildListCommand(t *testing.T, when spec.G, it spec.S) {
 				it("lists the builds", func() {
 					testhelpers.CommandTest{
 						Objects:        testhelpers.MakeTestBuilds(image, defaultNamespace),
-						Args:           []string{image},
+						Args:           nil,
 						ExpectedOutput: expectedOutput,
 					}.TestKpack(t, cmdFunc)
 				})
@@ -50,12 +51,13 @@ func testBuildListCommand(t *testing.T, when spec.G, it spec.S) {
 			when("there are no builds", func() {
 				it("prints an appropriate message", func() {
 					testhelpers.CommandTest{
-						Args:           []string{image},
+						Args:           nil,
 						ExpectErr:      true,
 						ExpectedOutput: "Error: no builds found\n",
 					}.TestKpack(t, cmdFunc)
 				})
 			})
+
 		})
 
 		when("in a given namespace", func() {
@@ -65,7 +67,7 @@ func testBuildListCommand(t *testing.T, when spec.G, it spec.S) {
 				it("lists the builds", func() {
 					testhelpers.CommandTest{
 						Objects:        testhelpers.MakeTestBuilds(image, namespace),
-						Args:           []string{image, "-n", namespace},
+						Args:           []string{"-n", namespace},
 						ExpectedOutput: expectedOutput,
 					}.TestKpack(t, cmdFunc)
 				})
@@ -74,7 +76,35 @@ func testBuildListCommand(t *testing.T, when spec.G, it spec.S) {
 			when("there are no builds", func() {
 				it("prints an appropriate message", func() {
 					testhelpers.CommandTest{
-						Args:           []string{image, "-n", namespace},
+						Args:           []string{"-n", namespace},
+						ExpectErr:      true,
+						ExpectedOutput: "Error: no builds found\n",
+					}.TestKpack(t, cmdFunc)
+				})
+			})
+		})
+
+		when("an image is specified", func() {
+			const expectedOutput = `BUILD    STATUS      IMAGE                   REASON
+1        SUCCESS     repo.com/image-1:tag    CONFIG
+2        FAILURE     repo.com/image-2:tag    COMMIT+
+3        BUILDING    repo.com/image-3:tag    TRIGGER
+
+`
+			when("there are builds", func() {
+				it("lists the builds of the image", func() {
+					testhelpers.CommandTest{
+						Objects:        testhelpers.MakeTestBuilds(image, defaultNamespace),
+						Args:           []string{image},
+						ExpectedOutput: expectedOutput,
+					}.TestKpack(t, cmdFunc)
+				})
+			})
+
+			when("there are no builds", func() {
+				it("prints an appropriate message", func() {
+					testhelpers.CommandTest{
+						Args:           []string{image},
 						ExpectErr:      true,
 						ExpectedOutput: "Error: no builds found\n",
 					}.TestKpack(t, cmdFunc)

--- a/pkg/testhelpers/build.go
+++ b/pkg/testhelpers/build.go
@@ -133,14 +133,18 @@ func MakeTestBuilds(image string, namespace string) []runtime.Object {
 			PodName:     "pod-three",
 		},
 	}
-	ignoredBuild := &v1alpha1.Build{
+	otherBuild := &v1alpha1.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ignored",
 			Namespace: namespace,
 			Labels: map[string]string{
 				v1alpha1.ImageLabel: "some-other-image",
+				v1alpha1.BuildNumberLabel: "1",
 			},
 		},
+		Status: v1alpha1.BuildStatus{
+			LatestImage: "repo.com/other-image-1:tag",
+		},
 	}
-	return []runtime.Object{buildOne, buildThree, buildTwo, ignoredBuild}
+	return []runtime.Object{buildOne, buildThree, buildTwo, otherBuild}
 }


### PR DESCRIPTION
**When** a user performs: `kp build list`
**List all builds** for a namespace, across images

**Example Output**:

```shell
$ go run ./cmd/kp/main.go build list 
BUILD    STATUS     IMAGE                                                                                                               REASON
1        SUCCESS    index.docker.io/aemengo/tutorial-app@sha256:04e7ac54c58da2a0d3b4a2bdc7b11dc53c4f080fa270506c26ccd2f1f928274a        CONFIG
2        SUCCESS    index.docker.io/aemengo/tutorial-app@sha256:1b5bb07d371b2978bdcb4be74b31e069de9f74278c73059c536723f64bdd6e31        BUILDPACK
3        SUCCESS    index.docker.io/aemengo/tutorial-app@sha256:a69254b13db2e0c6cf0c1ceea8665001b1b20a0c308644bee0907d85c51c48eb        BUILDPACK
1        SUCCESS    index.docker.io/aemengo/non-tutorial-app@sha256:b50fad6ccaee2c5ed0c45639dbf3dc776e3e3746798250962e4fb3b4777ccf15    CONFIG
2        SUCCESS    index.docker.io/aemengo/non-tutorial-app@sha256:e2697cf5a86e327f8ed369e64cd027d01bf7f7c31f54b8629147147bf93a4026    COMMIT
```

Addresses: https://github.com/vmware-tanzu/kpack-cli/issues/83