### PR TITLE
Use buildpackage id and version to remove buildpackges from the store

### DIFF
--- a/pkg/commands/clusterstore/remove.go
+++ b/pkg/commands/clusterstore/remove.go
@@ -4,6 +4,8 @@
 package clusterstore
 
 import (
+	"fmt"
+
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -21,11 +23,9 @@ func NewRemoveCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 		Use:   "remove <store> -b <buildpackage> [-b <buildpackage>...]",
 		Short: "Remove buildpackage(s) from cluster store",
 		Long: `Removes existing buildpackage(s) from a specific cluster-scoped buildpack store.
-
-This relies on the image(s) specified to exist in the store and removes the associated buildpackage(s)
 `,
-		Example: `kp clusterstore remove my-store -b my-registry.com/my-buildpackage/buildpacks_httpd@sha256:7a09cfeae4763207b9efeacecf914a57e4f5d6c4459226f6133ecaccb5c46271
-kp clusterstore remove my-store -b my-registry.com/my-buildpackage/buildpacks_httpd@sha256:7a09cfeae4763207b9efeacecf914a57e4f5d6c4459226f6133ecaccb5c46271 -b my-registry.com/my-buildpackage/buildpacks_nginx@sha256:eacecf914a57e4f5d6c4459226f6133ecaccb5c462717a09cfeae4763207b9ef
+		Example: `kp clusterstore remove my-store -b buildpackage@1.0.0
+kp clusterstore remove my-store -b buildpackage@1.0.0 -b other-buildpackage@2.0.0
 `,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
@@ -49,9 +49,12 @@ kp clusterstore remove my-store -b my-registry.com/my-buildpackage/buildpacks_ht
 				return err
 			}
 
-			for _, bpToRemove := range buildpackages {
-				if !storeContainsBuildpackage(store, bpToRemove) {
-					return errors.Errorf("Buildpackage '%s' does not exist in the ClusterStore", bpToRemove)
+			bpToStoreImage := map[string]v1alpha1.StoreImage{}
+			for _, bp := range buildpackages {
+				if ok, storeImage := getStoreImage(store, bp); !ok {
+					return errors.Errorf("Buildpackage '%s' does not exist in the ClusterStore", bp)
+				} else {
+					bpToStoreImage[bp] = storeImage
 				}
 			}
 
@@ -59,22 +62,7 @@ kp clusterstore remove my-store -b my-registry.com/my-buildpackage/buildpacks_ht
 				return err
 			}
 
-			var updatedStoreSources []v1alpha1.StoreImage
-			for _, storeImg := range store.Spec.Sources {
-				found := false
-				for _, bpToRemove := range buildpackages {
-					if storeImg.Image == bpToRemove {
-						found = true
-						ch.Printlnf("Removing buildpackage %s", bpToRemove)
-						break
-					}
-				}
-				if !found {
-					updatedStoreSources = append(updatedStoreSources, storeImg)
-				}
-			}
-
-			store.Spec.Sources = updatedStoreSources
+			removeBuildpackages(ch, store, buildpackages, bpToStoreImage)
 
 			if !ch.IsDryRun() {
 				store, err = cs.KpackClient.KpackV1alpha1().ClusterStores().Update(store)
@@ -95,11 +83,24 @@ kp clusterstore remove my-store -b my-registry.com/my-buildpackage/buildpacks_ht
 	return cmd
 }
 
-func storeContainsBuildpackage(store *v1alpha1.ClusterStore, buildpackage string) bool {
-	for _, source := range store.Spec.Sources {
-		if source.Image == buildpackage {
-			return true
+func getStoreImage(store *v1alpha1.ClusterStore, buildpackage string) (bool, v1alpha1.StoreImage) {
+	for _, bp := range store.Status.Buildpacks {
+		if fmt.Sprintf("%s@%s", bp.Id, bp.Version) == buildpackage {
+			return true, bp.StoreImage
 		}
 	}
-	return false
+	return false, v1alpha1.StoreImage{}
+}
+
+func removeBuildpackages(ch *commands.CommandHelper, store *v1alpha1.ClusterStore, buildpackages []string, bpToStoreImage map[string]v1alpha1.StoreImage) {
+	for _, bp := range buildpackages {
+		ch.Printlnf("Removing buildpackage %s", bp)
+
+		for i, img := range store.Spec.Sources {
+			if img.Image == bpToStoreImage[bp].Image {
+				store.Spec.Sources = append(store.Spec.Sources[:i], store.Spec.Sources[i+1:]...)
+				break
+			}
+		}
+	}
 }

--- a/pkg/commands/clusterstore/remove.go
+++ b/pkg/commands/clusterstore/remove.go
@@ -51,7 +51,7 @@ kp clusterstore remove my-store -b buildpackage@1.0.0 -b other-buildpackage@2.0.
 
 			bpToStoreImage := map[string]v1alpha1.StoreImage{}
 			for _, bp := range buildpackages {
-				if ok, storeImage := getStoreImage(store, bp); !ok {
+				if storeImage, ok := getStoreImage(store, bp); !ok {
 					return errors.Errorf("Buildpackage '%s' does not exist in the ClusterStore", bp)
 				} else {
 					bpToStoreImage[bp] = storeImage
@@ -83,13 +83,13 @@ kp clusterstore remove my-store -b buildpackage@1.0.0 -b other-buildpackage@2.0.
 	return cmd
 }
 
-func getStoreImage(store *v1alpha1.ClusterStore, buildpackage string) (bool, v1alpha1.StoreImage) {
+func getStoreImage(store *v1alpha1.ClusterStore, buildpackage string) (v1alpha1.StoreImage, bool) {
 	for _, bp := range store.Status.Buildpacks {
 		if fmt.Sprintf("%s@%s", bp.Id, bp.Version) == buildpackage {
-			return true, bp.StoreImage
+			return bp.StoreImage, true
 		}
 	}
-	return false, v1alpha1.StoreImage{}
+	return v1alpha1.StoreImage{}, false
 }
 
 func removeBuildpackages(ch *commands.CommandHelper, store *v1alpha1.ClusterStore, buildpackages []string, bpToStoreImage map[string]v1alpha1.StoreImage) {

--- a/pkg/commands/clusterstore/remove_test.go
+++ b/pkg/commands/clusterstore/remove_test.go
@@ -48,6 +48,28 @@ func testClusterStoreRemoveCommand(t *testing.T, when spec.G, it spec.S) {
 				},
 			},
 		},
+		Status: v1alpha1.ClusterStoreStatus{
+			Buildpacks: []v1alpha1.StoreBuildpack{
+				{
+					BuildpackInfo: v1alpha1.BuildpackInfo{
+						Id:      "some-buildpackage",
+						Version: "1.2.3",
+					},
+					StoreImage: v1alpha1.StoreImage{
+						Image: image1InStore,
+					},
+				},
+				{
+					BuildpackInfo: v1alpha1.BuildpackInfo{
+						Id:      "another-buildpackage",
+						Version: "4.5.6",
+					},
+					StoreImage: v1alpha1.StoreImage{
+						Image: image2InStore,
+					},
+				},
+			},
+		},
 	}
 
 	it("removes a single buildpackage from the store", func() {
@@ -57,7 +79,7 @@ func testClusterStoreRemoveCommand(t *testing.T, when spec.G, it spec.S) {
 			},
 			Args: []string{
 				storeName,
-				"--buildpackage", "some/imageinStore1@sha256:1231alreadyInStore",
+				"--buildpackage", "some-buildpackage@1.2.3",
 			},
 			ExpectErr: false,
 			ExpectUpdates: []clientgotesting.UpdateActionImpl{
@@ -71,11 +93,12 @@ func testClusterStoreRemoveCommand(t *testing.T, when spec.G, it spec.S) {
 								},
 							},
 						},
+						Status: store.Status,
 					},
 				},
 			},
 			ExpectedOutput: `Removing Buildpackages...
-Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
+Removing buildpackage some-buildpackage@1.2.3
 ClusterStore "some-store" updated
 `,
 		}.TestKpack(t, cmdFunc)
@@ -88,8 +111,8 @@ ClusterStore "some-store" updated
 			},
 			Args: []string{
 				storeName,
-				"-b", "some/imageinStore1@sha256:1231alreadyInStore",
-				"-b", "some/imageinStore2@sha256:1232alreadyInStore",
+				"-b", "some-buildpackage@1.2.3",
+				"-b", "another-buildpackage@4.5.6",
 			},
 			ExpectErr: false,
 			ExpectUpdates: []clientgotesting.UpdateActionImpl{
@@ -99,12 +122,13 @@ ClusterStore "some-store" updated
 						Spec: v1alpha1.ClusterStoreSpec{
 							Sources: []v1alpha1.StoreImage{},
 						},
+						Status: store.Status,
 					},
 				},
 			},
 			ExpectedOutput: `Removing Buildpackages...
-Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
-Removing buildpackage some/imageinStore2@sha256:1232alreadyInStore
+Removing buildpackage some-buildpackage@1.2.3
+Removing buildpackage another-buildpackage@4.5.6
 ClusterStore "some-store" updated
 `,
 		}.TestKpack(t, cmdFunc)
@@ -117,8 +141,8 @@ ClusterStore "some-store" updated
 			},
 			Args: []string{
 				"invalid-store",
-				"-b", "some/imageinStore1@sha256:1231alreadyInStore",
-				"-b", "some/imageNotinStore@sha256:1232notInStore",
+				"-b", "some-buildpackage@1.2.3",
+				"-b", "another-buildpackage@4.5.6",
 			},
 			ExpectErr:      true,
 			ExpectedOutput: "Error: ClusterStore 'invalid-store' does not exist\n",
@@ -132,11 +156,11 @@ ClusterStore "some-store" updated
 			},
 			Args: []string{
 				storeName,
-				"-b", "some/imageinStore1@sha256:1231alreadyInStore",
-				"-b", "some/imageNotinStore@sha256:1232notInStore",
+				"-b", "some-buildpackage@1.2.3",
+				"-b", "does-not-exist-buildpackage@7.8.9",
 			},
 			ExpectErr:      true,
-			ExpectedOutput: "Error: Buildpackage 'some/imageNotinStore@sha256:1232notInStore' does not exist in the ClusterStore\n",
+			ExpectedOutput: "Error: Buildpackage 'does-not-exist-buildpackage@7.8.9' does not exist in the ClusterStore\n",
 		}.TestKpack(t, cmdFunc)
 	})
 
@@ -147,11 +171,10 @@ ClusterStore "some-store" updated
 			},
 			Args: []string{
 				storeName,
-				"-b",
-				"some/imageNotinStore@sha256:1233alreadyInStore",
+				"-b", "does-not-exist-buildpackage@7.8.9",
 			},
 			ExpectErr:      true,
-			ExpectedOutput: "Error: Buildpackage 'some/imageNotinStore@sha256:1233alreadyInStore' does not exist in the ClusterStore\n",
+			ExpectedOutput: "Error: Buildpackage 'does-not-exist-buildpackage@7.8.9' does not exist in the ClusterStore\n",
 		}.TestKpack(t, cmdFunc)
 	})
 
@@ -165,7 +188,18 @@ metadata:
 spec:
   sources:
   - image: some/imageinStore2@sha256:1232alreadyInStore
-status: {}
+status:
+  buildpacks:
+  - buildpackage: {}
+    id: some-buildpackage
+    storeImage:
+      image: some/imageinStore1@sha256:1231alreadyInStore
+    version: 1.2.3
+  - buildpackage: {}
+    id: another-buildpackage
+    storeImage:
+      image: some/imageinStore2@sha256:1232alreadyInStore
+    version: 4.5.6
 `
 
 			testhelpers.CommandTest{
@@ -174,7 +208,7 @@ status: {}
 				},
 				Args: []string{
 					storeName,
-					"--buildpackage", "some/imageinStore1@sha256:1231alreadyInStore",
+					"--buildpackage", "some-buildpackage@1.2.3",
 					"--output", "yaml",
 				},
 				ExpectUpdates: []clientgotesting.UpdateActionImpl{
@@ -188,34 +222,19 @@ status: {}
 									},
 								},
 							},
+							Status: store.Status,
 						},
 					},
 				},
 				ExpectedOutput: resourceYAML,
 				ExpectedErrorOutput: `Removing Buildpackages...
-Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
+Removing buildpackage some-buildpackage@1.2.3
 `,
 			}.TestKpack(t, cmdFunc)
 		})
 
 		it("can output in json format", func() {
-			const resourceJSON = `{
-    "kind": "ClusterStore",
-    "apiVersion": "kpack.io/v1alpha1",
-    "metadata": {
-        "name": "some-store",
-        "creationTimestamp": null
-    },
-    "spec": {
-        "sources": [
-            {
-                "image": "some/imageinStore2@sha256:1232alreadyInStore"
-            }
-        ]
-    },
-    "status": {}
-}
-`
+			const resourceJSON = "{\n    \"kind\": \"ClusterStore\",\n    \"apiVersion\": \"kpack.io/v1alpha1\",\n    \"metadata\": {\n        \"name\": \"some-store\",\n        \"creationTimestamp\": null\n    },\n    \"spec\": {\n        \"sources\": [\n            {\n                \"image\": \"some/imageinStore2@sha256:1232alreadyInStore\"\n            }\n        ]\n    },\n    \"status\": {\n        \"buildpacks\": [\n            {\n                \"id\": \"some-buildpackage\",\n                \"version\": \"1.2.3\",\n                \"buildpackage\": {},\n                \"storeImage\": {\n                    \"image\": \"some/imageinStore1@sha256:1231alreadyInStore\"\n                }\n            },\n            {\n                \"id\": \"another-buildpackage\",\n                \"version\": \"4.5.6\",\n                \"buildpackage\": {},\n                \"storeImage\": {\n                    \"image\": \"some/imageinStore2@sha256:1232alreadyInStore\"\n                }\n            }\n        ]\n    }\n}\n"
 
 			testhelpers.CommandTest{
 				Objects: []runtime.Object{
@@ -223,7 +242,7 @@ Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
 				},
 				Args: []string{
 					storeName,
-					"--buildpackage", "some/imageinStore1@sha256:1231alreadyInStore",
+					"--buildpackage", "some-buildpackage@1.2.3",
 					"--output", "json",
 				},
 				ExpectUpdates: []clientgotesting.UpdateActionImpl{
@@ -237,12 +256,13 @@ Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
 									},
 								},
 							},
+							Status: store.Status,
 						},
 					},
 				},
 				ExpectedOutput: resourceJSON,
 				ExpectedErrorOutput: `Removing Buildpackages...
-Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
+Removing buildpackage some-buildpackage@1.2.3
 `,
 			}.TestKpack(t, cmdFunc)
 		})
@@ -254,8 +274,8 @@ Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
 				},
 				Args: []string{
 					"invalid-store",
-					"-b", "some/imageinStore1@sha256:1231alreadyInStore",
-					"-b", "some/imageNotinStore@sha256:1232notInStore",
+					"-b", "some-buildpackage@1.2.3",
+					"-b", "another-buildpackage@4.5.6",
 					"--output", "yaml",
 				},
 				ExpectErr:      true,
@@ -272,11 +292,11 @@ Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
 				},
 				Args: []string{
 					storeName,
-					"--buildpackage", "some/imageinStore1@sha256:1231alreadyInStore",
+					"--buildpackage", "some-buildpackage@1.2.3",
 					"--dry-run",
 				},
 				ExpectedOutput: `Removing Buildpackages... (dry run)
-Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
+Removing buildpackage some-buildpackage@1.2.3
 ClusterStore "some-store" updated (dry run)
 `,
 			}.TestKpack(t, cmdFunc)
@@ -289,8 +309,8 @@ ClusterStore "some-store" updated (dry run)
 				},
 				Args: []string{
 					"invalid-store",
-					"-b", "some/imageinStore1@sha256:1231alreadyInStore",
-					"-b", "some/imageNotinStore@sha256:1232notInStore",
+					"-b", "some-buildpackage@1.2.3",
+					"-b", "another-buildpackage@4.5.6",
 					"--dry-run",
 				},
 				ExpectErr:      true,
@@ -308,7 +328,18 @@ metadata:
 spec:
   sources:
   - image: some/imageinStore2@sha256:1232alreadyInStore
-status: {}
+status:
+  buildpacks:
+  - buildpackage: {}
+    id: some-buildpackage
+    storeImage:
+      image: some/imageinStore1@sha256:1231alreadyInStore
+    version: 1.2.3
+  - buildpackage: {}
+    id: another-buildpackage
+    storeImage:
+      image: some/imageinStore2@sha256:1232alreadyInStore
+    version: 4.5.6
 `
 
 				testhelpers.CommandTest{
@@ -317,13 +348,13 @@ status: {}
 					},
 					Args: []string{
 						storeName,
-						"--buildpackage", "some/imageinStore1@sha256:1231alreadyInStore",
+						"--buildpackage", "some-buildpackage@1.2.3",
 						"--dry-run",
 						"--output", "yaml",
 					},
 					ExpectedOutput: resourceYAML,
 					ExpectedErrorOutput: `Removing Buildpackages... (dry run)
-Removing buildpackage some/imageinStore1@sha256:1231alreadyInStore
+Removing buildpackage some-buildpackage@1.2.3
 `,
 				}.TestKpack(t, cmdFunc)
 			})


### PR DESCRIPTION
No longer support removing buildpackages by fully qualified image name.