### PR TITLE
Fix registry issue when running on windows

### DIFF
--- a/pkg/builder/helpers.go
+++ b/pkg/builder/helpers.go
@@ -63,7 +63,7 @@ func CreateOrder(buildpacks []string) []v1alpha1.OrderEntry {
 }
 
 func CreateDetectionOrderRow(ref v1alpha1.BuildpackRef) (string, string) {
-	data := fmt.Sprintf("  %s",ref.Id)
+	data := fmt.Sprintf("  %s", ref.Id)
 	optional := ""
 
 	if ref.Version != "" {

--- a/pkg/commands/builder/status.go
+++ b/pkg/commands/builder/status.go
@@ -5,7 +5,6 @@ package builder
 
 import (
 	"fmt"
-	"github.com/pivotal/build-service-cli/pkg/builder"
 	"io"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
@@ -14,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/pivotal/build-service-cli/pkg/builder"
 	"github.com/pivotal/build-service-cli/pkg/commands"
 	"github.com/pivotal/build-service-cli/pkg/k8s"
 )

--- a/pkg/commands/builder/status_test.go
+++ b/pkg/commands/builder/status_test.go
@@ -436,7 +436,7 @@ Reason:    this builder is not ready for the purpose of a test
 									Group: []v1alpha1.BuildpackRef{
 										{
 											BuildpackInfo: v1alpha1.BuildpackInfo{
-												Id: "org.cloudfoundry.nodejs",
+												Id:      "org.cloudfoundry.nodejs",
 												Version: "0.2.1",
 											},
 										},
@@ -446,7 +446,7 @@ Reason:    this builder is not ready for the purpose of a test
 									Group: []v1alpha1.BuildpackRef{
 										{
 											BuildpackInfo: v1alpha1.BuildpackInfo{
-												Id: "org.cloudfoundry.go",
+												Id:      "org.cloudfoundry.go",
 												Version: "0.0.3",
 											},
 										},

--- a/pkg/commands/clusterbuilder/status.go
+++ b/pkg/commands/clusterbuilder/status.go
@@ -5,7 +5,6 @@ package clusterbuilder
 
 import (
 	"fmt"
-	"github.com/pivotal/build-service-cli/pkg/builder"
 	"io"
 
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
@@ -14,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/pivotal/build-service-cli/pkg/builder"
 	"github.com/pivotal/build-service-cli/pkg/commands"
 	"github.com/pivotal/build-service-cli/pkg/k8s"
 )

--- a/pkg/commands/clusterbuilder/status_test.go
+++ b/pkg/commands/clusterbuilder/status_test.go
@@ -272,7 +272,7 @@ Reason:    this builder is not ready for the purpose of a test
 								Group: []v1alpha1.BuildpackRef{
 									{
 										BuildpackInfo: v1alpha1.BuildpackInfo{
-											Id: "org.cloudfoundry.nodejs",
+											Id:      "org.cloudfoundry.nodejs",
 											Version: "0.2.1",
 										},
 									},
@@ -282,7 +282,7 @@ Reason:    this builder is not ready for the purpose of a test
 								Group: []v1alpha1.BuildpackRef{
 									{
 										BuildpackInfo: v1alpha1.BuildpackInfo{
-											Id: "org.cloudfoundry.go",
+											Id:      "org.cloudfoundry.go",
 											Version: "0.0.3",
 										},
 									},

--- a/pkg/registry/fetcher.go
+++ b/pkg/registry/fetcher.go
@@ -5,6 +5,7 @@ package registry
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -26,6 +27,12 @@ func (d DefaultFetcher) Fetch(src string, tlsCfg TLSConfig) (v1.Image, error) {
 		imageRef, err := name.ParseReference(src, name.WeakValidation)
 		if err != nil {
 			return nil, err
+		}
+
+		// Do not verify with custom CA on windows when reading from registry
+		// https://github.com/golang/go/issues/16736
+		if runtime.GOOS == "windows" {
+			tlsCfg.CaCertPath = ""
 		}
 
 		t, err := tlsCfg.Transport()

--- a/pkg/registry/tls_config_test.go
+++ b/pkg/registry/tls_config_test.go
@@ -21,7 +21,7 @@ func TestTLSConfig(t *testing.T) {
 }
 
 func testTLSConfig(t *testing.T, when spec.G, it spec.S) {
-	it("it adds the cert to the cert pool and sets skip tls verify", func() {
+	it("adds the cert to the cert pool and sets skip tls verify", func() {
 		certPath := filepath.Join("testdata", "ca.crt")
 		certData, err := ioutil.ReadFile(certPath)
 		require.NoError(t, err)
@@ -52,7 +52,7 @@ func testTLSConfig(t *testing.T, when spec.G, it spec.S) {
 		require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 	})
 
-	it("it sets skip verify to false when verify certs is true", func() {
+	it("sets skip verify to false when verify certs is true", func() {
 		fetcher := registry.TLSConfig{
 			CaCertPath:  "",
 			VerifyCerts: true,


### PR DESCRIPTION
- Do not verify with custom CAs when reading from a registry on windows
- Do not set TLSClientConfig.RootCAs when no custom CA is used on windows
- goimports

https://github.com/vmware-tanzu/kpack-cli/issues/128

Note:
- Did not add tests as this behavior is minor and will only be a concern on windows