### PR TITLE
Add filter funtionality to image list command

### DIFF
--- a/pkg/commands/image/list.go
+++ b/pkg/commands/image/list.go
@@ -49,7 +49,10 @@ kp image list --filter ready=true --filter latest-reason=commit,trigger`,
 				return err
 			}
 
-			imageList = filterImageList(imageList, filters)
+			imageList, err = filterImageList(imageList, filters)
+			if err != nil {
+				return err
+			}
 
 			if len(imageList.Items) == 0 {
 				return errors.New("no images found")

--- a/pkg/commands/image/list.go
+++ b/pkg/commands/image/list.go
@@ -29,7 +29,7 @@ The namespace defaults to the kubernetes current-context namespace.`,
 		Example: `kp image list
 kp image list -A
 kp image list -n my-namespace
-kp image list --filter ready=true`,
+kp image list --filter ready=true --filter latest-reason=commit,trigger`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cs, err := clientSetProvider.GetClientSet(namespace)
 			if err != nil {
@@ -49,7 +49,7 @@ kp image list --filter ready=true`,
 				return err
 			}
 
-			imageList = Filter(imageList, filters)
+			imageList = filterImageList(imageList, filters)
 
 			if len(imageList.Items) == 0 {
 				return errors.New("no images found")
@@ -63,13 +63,13 @@ kp image list --filter ready=true`,
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "kubernetes namespace")
 	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Return objects found in all namespaces")
 	cmd.Flags().StringArrayVar(&filters, "filter", nil,
-		`Each new filter argument requires an additoinal filter flag.
+		`Each new filter argument requires an additional filter flag.
 Multiple values can be provided using comma separation.
 Supported filters and values:
-builder=string
-clusterbuilder=string
-latest-reason=commit, trigger, config, stack, buildpack
-ready=true, false, unknown`)
+  builder=string
+  clusterbuilder=string
+  latest-reason=commit, trigger, config, stack, buildpack
+  ready=true, false, unknown`)
 
 	return cmd
 }

--- a/pkg/commands/image/list_filter.go
+++ b/pkg/commands/image/list_filter.go
@@ -9,26 +9,18 @@ import (
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 )
 
-const (
-	filterKindBuilder        = "builder"
-	filterKindClusterBuilder = "clusterbuilder"
-	filterKindLatestReason   = "latest-reason"
-	filterKindStatus         = "ready"
-)
-
 type filter struct {
-	kind   string
-	values []string
+	filterFunc func(image v1alpha1.Image, values []string) bool
+	values     []string
 }
 
-func Filter(images *v1alpha1.ImageList, flags []string) *v1alpha1.ImageList {
+func filterImageList(images *v1alpha1.ImageList, flags []string) *v1alpha1.ImageList {
 	filters := parseFilters(flags)
 	if len(filters) == 0 {
 		return images
 	}
 
 	var filteredItems []v1alpha1.Image
-
 	for _, item := range images.Items {
 		if matchesAll(item, filters) {
 			filteredItems = append(filteredItems, item)
@@ -51,22 +43,26 @@ func parseFilters(flags []string) []filter {
 	for _, flag := range flags {
 		m := builderRegex.FindStringSubmatch(flag)
 		if len(m) == 2 {
-			filters = append(filters, filter{kind: filterKindBuilder, values: m[1:]})
+			filters = append(filters, filter{values: m[1:], filterFunc: func(image v1alpha1.Image, values []string) bool {
+				return image.Spec.Builder.Kind == v1alpha1.BuilderKind && image.Spec.Builder.Name == values[0]
+			}})
 		}
 
 		m = clusterBuilderRegex.FindStringSubmatch(flag)
 		if len(m) == 2 {
-			filters = append(filters, filter{kind: filterKindClusterBuilder, values: m[1:]})
+			filters = append(filters, filter{values: m[1:], filterFunc: func(image v1alpha1.Image, values []string) bool {
+				return image.Spec.Builder.Kind == v1alpha1.ClusterBuilderKind && image.Spec.Builder.Name == values[0]
+			}})
 		}
 
 		m = latestReasonRegex.FindStringSubmatch(flag)
 		if len(m) == 2 {
-			filters = append(filters, filter{kind: filterKindLatestReason, values: strings.Split(m[1], ",")})
+			filters = append(filters, filter{values: strings.Split(m[1], ","), filterFunc: matchesLatestReason})
 		}
 
 		m = statusRegex.FindStringSubmatch(flag)
 		if len(m) == 2 {
-			filters = append(filters, filter{kind: filterKindStatus, values: strings.Split(m[1], ",")})
+			filters = append(filters, filter{values: strings.Split(m[1], ","), filterFunc: matchesStatus})
 		}
 	}
 
@@ -75,35 +71,12 @@ func parseFilters(flags []string) []filter {
 
 func matchesAll(image v1alpha1.Image, fs []filter) bool {
 	for _, f := range fs {
-		if !matches(image, f) {
+		if !f.filterFunc(image, f.values) {
 			return false
 		}
 	}
 
 	return true
-}
-
-func matches(image v1alpha1.Image, f filter) bool {
-	switch f.kind {
-	case filterKindBuilder:
-		if image.Spec.Builder.Kind == v1alpha1.BuilderKind && image.Spec.Builder.Name == f.values[0] {
-			return true
-		}
-	case filterKindClusterBuilder:
-		if image.Spec.Builder.Kind == v1alpha1.ClusterBuilderKind && image.Spec.Builder.Name == f.values[0] {
-			return true
-		}
-	case filterKindStatus:
-		if matchesStatus(image, f.values) {
-			return true
-		}
-	case filterKindLatestReason:
-		if matchesLatestReason(image, f.values) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func matchesStatus(image v1alpha1.Image, values []string) bool {
@@ -119,25 +92,20 @@ func matchesStatus(image v1alpha1.Image, values []string) bool {
 
 	cond := image.Status.GetCondition(corev1alpha1.ConditionReady)
 
-	if cond == nil {
-		if contains(corev1.ConditionUnknown) {
-			return true
-		} else {
-			return false
-		}
-	}
-
-	if contains(cond.Status) {
-		return true
-	} else {
-		return false
+	switch cond {
+	case nil:
+		return contains(corev1.ConditionUnknown)
+	default:
+		return contains(cond.Status)
 	}
 }
 
 func matchesLatestReason(image v1alpha1.Image, values []string) bool {
 	for _, v := range values {
-		if strings.ToLower(image.Status.LatestBuildReason) == strings.ToLower(v) {
-			return true
+		for _, reason := range strings.Split(image.Status.LatestBuildReason, ",") {
+			if strings.ToLower(reason) == strings.ToLower(v) {
+				return true
+			}
 		}
 	}
 

--- a/pkg/commands/image/list_filter.go
+++ b/pkg/commands/image/list_filter.go
@@ -1,0 +1,145 @@
+package image
+
+import (
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"regexp"
+	"strings"
+
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+)
+
+const (
+	filterKindBuilder        = "builder"
+	filterKindClusterBuilder = "clusterbuilder"
+	filterKindLatestReason   = "latest-reason"
+	filterKindStatus         = "ready"
+)
+
+type filter struct {
+	kind   string
+	values []string
+}
+
+func Filter(images *v1alpha1.ImageList, flags []string) *v1alpha1.ImageList {
+	filters := parseFilters(flags)
+	if len(filters) == 0 {
+		return images
+	}
+
+	var filteredItems []v1alpha1.Image
+
+	for _, item := range images.Items {
+		if matchesAll(item, filters) {
+			filteredItems = append(filteredItems, item)
+		}
+	}
+
+	images.Items = filteredItems
+	return images
+}
+
+func parseFilters(flags []string) []filter {
+	var (
+		filters             []filter
+		builderRegex        = regexp.MustCompile(`^builder=(.*)$`)
+		clusterBuilderRegex = regexp.MustCompile(`^clusterbuilder=(.*)$`)
+		latestReasonRegex   = regexp.MustCompile(`^latest-reason=(.*)$`)
+		statusRegex         = regexp.MustCompile(`^ready=(.*)$`)
+	)
+
+	for _, flag := range flags {
+		m := builderRegex.FindStringSubmatch(flag)
+		if len(m) == 2 {
+			filters = append(filters, filter{kind: filterKindBuilder, values: m[1:]})
+		}
+
+		m = clusterBuilderRegex.FindStringSubmatch(flag)
+		if len(m) == 2 {
+			filters = append(filters, filter{kind: filterKindClusterBuilder, values: m[1:]})
+		}
+
+		m = latestReasonRegex.FindStringSubmatch(flag)
+		if len(m) == 2 {
+			filters = append(filters, filter{kind: filterKindLatestReason, values: strings.Split(m[1], ",")})
+		}
+
+		m = statusRegex.FindStringSubmatch(flag)
+		if len(m) == 2 {
+			filters = append(filters, filter{kind: filterKindStatus, values: strings.Split(m[1], ",")})
+		}
+	}
+
+	return filters
+}
+
+func matchesAll(image v1alpha1.Image, fs []filter) bool {
+	for _, f := range fs {
+		if !matches(image, f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matches(image v1alpha1.Image, f filter) bool {
+	switch f.kind {
+	case filterKindBuilder:
+		if image.Spec.Builder.Kind == v1alpha1.BuilderKind && image.Spec.Builder.Name == f.values[0] {
+			return true
+		}
+	case filterKindClusterBuilder:
+		if image.Spec.Builder.Kind == v1alpha1.ClusterBuilderKind && image.Spec.Builder.Name == f.values[0] {
+			return true
+		}
+	case filterKindStatus:
+		if matchesStatus(image, f.values) {
+			return true
+		}
+	case filterKindLatestReason:
+		if matchesLatestReason(image, f.values) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func matchesStatus(image v1alpha1.Image, values []string) bool {
+	contains := func(q corev1.ConditionStatus) bool {
+		for _, v := range values {
+			if strings.ToLower(string(q)) == strings.ToLower(v) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	cond := image.Status.GetCondition(corev1alpha1.ConditionReady)
+
+	if cond == nil {
+		if contains(corev1.ConditionUnknown) {
+			return true
+		} else {
+			return false
+		}
+	}
+
+	if contains(cond.Status) {
+		return true
+	} else {
+		return false
+	}
+}
+
+func matchesLatestReason(image v1alpha1.Image, values []string) bool {
+	for _, v := range values {
+		if strings.ToLower(image.Status.LatestBuildReason) == strings.ToLower(v) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/commands/image/list_filter_test.go
+++ b/pkg/commands/image/list_filter_test.go
@@ -75,7 +75,9 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the builder filter is specified", func() {
 		it("filters images", func() {
-			imgs := filterImageList(images, []string{"builder=some-builder"})
+			imgs, err := filterImageList(images, []string{"builder=some-builder"})
+			require.NoError(t, err)
+
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-1", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -83,7 +85,9 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the clusterbuilder filter is specified", func() {
 		it("filters images", func() {
-			imgs := filterImageList(images, []string{"clusterbuilder=some-cluster-builder"})
+			imgs, err := filterImageList(images, []string{"clusterbuilder=some-cluster-builder"})
+			require.NoError(t, err)
+
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-2", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -91,7 +95,9 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the status filter is specified", func() {
 		it("filters images", func() {
-			imgs := filterImageList(images, []string{"ready=true,some-other-status"})
+			imgs, err := filterImageList(images, []string{"ready=true,some-other-status"})
+			require.NoError(t, err)
+
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-3", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -99,7 +105,9 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the latest-reason filter is specified", func() {
 		it("filters images", func() {
-			imgs := filterImageList(images, []string{"latest-reason=commit,some-other-build-reason"})
+			imgs, err := filterImageList(images, []string{"latest-reason=commit,some-other-build-reason"})
+			require.NoError(t, err)
+
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-4", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -142,9 +150,18 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("multiple filters are specified", func() {
 		it("filters images matching all criteria", func() {
-			imgs := filterImageList(imagesWithSameBuilder, []string{"builder=some-builder", "latest-reason=commit"})
+			imgs, err := filterImageList(imagesWithSameBuilder, []string{"builder=some-builder", "latest-reason=commit"})
+			require.NoError(t, err)
+
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-1", imgs.Items[0].ObjectMeta.Name)
+		})
+	})
+
+	when("an invalid filter is specified", func() {
+		it("returns a helpful error message", func() {
+			_, err := filterImageList(imagesWithSameBuilder, []string{"some-invalid-filter=some-value"})
+			require.Error(t, err, "invalid filter argument \"some-invalid-filter=some-value\"")
 		})
 	})
 

--- a/pkg/commands/image/list_filter_test.go
+++ b/pkg/commands/image/list_filter_test.go
@@ -1,0 +1,152 @@
+// Copyright 2020-Present VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package image_test
+
+import (
+	"github.com/pivotal/build-service-cli/pkg/commands/image"
+	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+
+	"github.com/sclevine/spec"
+)
+
+func TestFilter(t *testing.T) {
+	spec.Run(t, "TestFilter", testFilter)
+}
+
+func testFilter(t *testing.T, when spec.G, it spec.S) {
+	images := &v1alpha1.ImageList{
+		Items: []v1alpha1.Image{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-image-1",
+					Namespace: "some-namespace",
+				},
+				Spec: v1alpha1.ImageSpec{
+					Builder: corev1.ObjectReference{
+						Kind:            v1alpha1.BuilderKind,
+						Name:            "some-builder",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-image-2",
+					Namespace: "some-namespace",
+				},
+				Spec: v1alpha1.ImageSpec{
+					Builder: corev1.ObjectReference{
+						Kind:            v1alpha1.ClusterBuilderKind,
+						Name:            "some-cluster-builder",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-image-3",
+					Namespace: "some-namespace",
+				},
+				Status: v1alpha1.ImageStatus{
+					Status: corev1alpha1.Status{
+						Conditions: []corev1alpha1.Condition{
+							{
+								Type:   corev1alpha1.ConditionReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-image-4",
+					Namespace: "some-namespace",
+				},
+				Status: v1alpha1.ImageStatus{
+					LatestBuildReason: "COMMIT",
+				},
+			},
+		},
+	}
+
+	when("the builder filter is specified", func() {
+		it("filters images", func() {
+			imgs := image.Filter(images, []string{"builder=some-builder"})
+			require.Len(t, imgs.Items, 1)
+			require.Equal(t, "test-image-1", imgs.Items[0].ObjectMeta.Name)
+		})
+	})
+
+	when("the clusterbuilder filter is specified", func() {
+		it("filters images", func() {
+			imgs := image.Filter(images, []string{"clusterbuilder=some-cluster-builder"})
+			require.Len(t, imgs.Items, 1)
+			require.Equal(t, "test-image-2", imgs.Items[0].ObjectMeta.Name)
+		})
+	})
+
+	when("the status filter is specified", func() {
+		it("filters images", func() {
+			imgs := image.Filter(images, []string{"ready=true,some-other-status"})
+			require.Len(t, imgs.Items, 1)
+			require.Equal(t, "test-image-3", imgs.Items[0].ObjectMeta.Name)
+		})
+	})
+
+	when("the latest-reason filter is specified", func() {
+		it("filters images", func() {
+			imgs := image.Filter(images, []string{"latest-reason=commit,some-other-build-reason"})
+			require.Len(t, imgs.Items, 1)
+			require.Equal(t, "test-image-4", imgs.Items[0].ObjectMeta.Name)
+		})
+	})
+
+	imagesWithSameBuilder := &v1alpha1.ImageList{
+		Items: []v1alpha1.Image{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-image-1",
+					Namespace: "some-namespace",
+				},
+				Spec: v1alpha1.ImageSpec{
+					Builder: corev1.ObjectReference{
+						Kind:            v1alpha1.BuilderKind,
+						Name:            "some-builder",
+					},
+				},
+				Status: v1alpha1.ImageStatus{
+					LatestBuildReason: "COMMIT",
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "some-ignored-test-image",
+					Namespace: "some-namespace",
+				},
+				Spec: v1alpha1.ImageSpec{
+					Builder: corev1.ObjectReference{
+						Kind:            v1alpha1.BuilderKind,
+						Name:            "some-builder",
+					},
+				},
+				Status: v1alpha1.ImageStatus{
+					LatestBuildReason: "some-other-build-reason",
+				},
+			},
+		},
+	}
+
+	when("multiple filters are specified", func() {
+		it("filters images matching all criteria", func() {
+			imgs := image.Filter(imagesWithSameBuilder, []string{"builder=some-builder", "latest-reason=commit"})
+			require.Len(t, imgs.Items, 1)
+			require.Equal(t, "test-image-1", imgs.Items[0].ObjectMeta.Name)
+		})
+	})
+
+}

--- a/pkg/commands/image/list_filter_test.go
+++ b/pkg/commands/image/list_filter_test.go
@@ -1,10 +1,9 @@
 // Copyright 2020-Present VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package image_test
+package image
 
 import (
-	"github.com/pivotal/build-service-cli/pkg/commands/image"
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/stretchr/testify/require"
@@ -68,7 +67,7 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 					Namespace: "some-namespace",
 				},
 				Status: v1alpha1.ImageStatus{
-					LatestBuildReason: "COMMIT",
+					LatestBuildReason: "COMMIT,BUILDPACK",
 				},
 			},
 		},
@@ -76,7 +75,7 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the builder filter is specified", func() {
 		it("filters images", func() {
-			imgs := image.Filter(images, []string{"builder=some-builder"})
+			imgs := filterImageList(images, []string{"builder=some-builder"})
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-1", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -84,7 +83,7 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the clusterbuilder filter is specified", func() {
 		it("filters images", func() {
-			imgs := image.Filter(images, []string{"clusterbuilder=some-cluster-builder"})
+			imgs := filterImageList(images, []string{"clusterbuilder=some-cluster-builder"})
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-2", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -92,7 +91,7 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the status filter is specified", func() {
 		it("filters images", func() {
-			imgs := image.Filter(images, []string{"ready=true,some-other-status"})
+			imgs := filterImageList(images, []string{"ready=true,some-other-status"})
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-3", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -100,7 +99,7 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("the latest-reason filter is specified", func() {
 		it("filters images", func() {
-			imgs := image.Filter(images, []string{"latest-reason=commit,some-other-build-reason"})
+			imgs := filterImageList(images, []string{"latest-reason=commit,some-other-build-reason"})
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-4", imgs.Items[0].ObjectMeta.Name)
 		})
@@ -143,7 +142,7 @@ func testFilter(t *testing.T, when spec.G, it spec.S) {
 
 	when("multiple filters are specified", func() {
 		it("filters images matching all criteria", func() {
-			imgs := image.Filter(imagesWithSameBuilder, []string{"builder=some-builder", "latest-reason=commit"})
+			imgs := filterImageList(imagesWithSameBuilder, []string{"builder=some-builder", "latest-reason=commit"})
 			require.Len(t, imgs.Items, 1)
 			require.Equal(t, "test-image-1", imgs.Items[0].ObjectMeta.Name)
 		})

--- a/pkg/commands/image/list_test.go
+++ b/pkg/commands/image/list_test.go
@@ -40,6 +40,7 @@ func testImageListCommand(t *testing.T, when spec.G, it spec.S) {
 						Namespace: "test-namespace",
 					},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -57,6 +58,7 @@ func testImageListCommand(t *testing.T, when spec.G, it spec.S) {
 						Namespace: "test-namespace",
 					},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -75,6 +77,7 @@ func testImageListCommand(t *testing.T, when spec.G, it spec.S) {
 					},
 					Spec: v1alpha1.ImageSpec{},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -92,6 +95,7 @@ func testImageListCommand(t *testing.T, when spec.G, it spec.S) {
 						Namespace: defaultNamespace,
 					},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -112,10 +116,10 @@ func testImageListCommand(t *testing.T, when spec.G, it spec.S) {
 						notInNamespaceImage,
 					},
 					Args: []string{"-n", "test-namespace"},
-					ExpectedOutput: `NAME            READY      LATEST IMAGE
-test-image-1    False      test-registry.io/test-image-1@sha256:abcdef123
-test-image-2    Unknown    test-registry.io/test-image-2@sha256:abcdef123
-test-image-3    True       test-registry.io/test-image-3@sha256:abcdef123
+					ExpectedOutput: `NAME            READY      LATEST REASON    LATEST IMAGE                                      NAMESPACE
+test-image-1    False      COMMIT           test-registry.io/test-image-1@sha256:abcdef123    test-namespace
+test-image-2    Unknown    COMMIT           test-registry.io/test-image-2@sha256:abcdef123    test-namespace
+test-image-3    True       COMMIT           test-registry.io/test-image-3@sha256:abcdef123    test-namespace
 
 `,
 				}.TestKpack(t, cmdFunc)
@@ -143,6 +147,7 @@ test-image-3    True       test-registry.io/test-image-3@sha256:abcdef123
 						Namespace: defaultNamespace,
 					},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -161,6 +166,7 @@ test-image-3    True       test-registry.io/test-image-3@sha256:abcdef123
 						Namespace: defaultNamespace,
 					},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -180,6 +186,7 @@ test-image-3    True       test-registry.io/test-image-3@sha256:abcdef123
 					},
 					Spec: v1alpha1.ImageSpec{},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -198,6 +205,7 @@ test-image-3    True       test-registry.io/test-image-3@sha256:abcdef123
 						Namespace: "not-default-namespace",
 					},
 					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
 								{
@@ -217,10 +225,120 @@ test-image-3    True       test-registry.io/test-image-3@sha256:abcdef123
 						image3,
 						notDefaultNamespaceImage,
 					},
-					ExpectedOutput: `NAME            READY      LATEST IMAGE
-test-image-1    False      test-registry.io/test-image-1@sha256:abcdef123
-test-image-2    Unknown    test-registry.io/test-image-2@sha256:abcdef123
-test-image-3    True       test-registry.io/test-image-3@sha256:abcdef123
+					ExpectedOutput: `NAME            READY      LATEST REASON    LATEST IMAGE                                      NAMESPACE
+test-image-1    False      COMMIT           test-registry.io/test-image-1@sha256:abcdef123    some-default-namespace
+test-image-2    Unknown    COMMIT           test-registry.io/test-image-2@sha256:abcdef123    some-default-namespace
+test-image-3    True       COMMIT           test-registry.io/test-image-3@sha256:abcdef123    some-default-namespace
+
+`,
+				}.TestKpack(t, cmdFunc)
+			})
+
+			when("the namespace has no images", func() {
+				it("returns a message that the namespace has no images", func() {
+					testhelpers.CommandTest{
+						ExpectErr:      true,
+						ExpectedOutput: "Error: no images found\n",
+					}.TestKpack(t, cmdFunc)
+
+				})
+			})
+		})
+	})
+
+	when("all namespaces is specified", func() {
+		when("the namespaces has images", func() {
+			it("returns a table of image details", func() {
+				image1 := &v1alpha1.Image{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-image-1",
+						Namespace: defaultNamespace,
+					},
+					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
+						Status: corev1alpha1.Status{
+							Conditions: []corev1alpha1.Condition{
+								{
+									Type:   corev1alpha1.ConditionReady,
+									Status: corev1.ConditionFalse,
+								},
+							},
+						},
+						LatestImage: "test-registry.io/test-image-1@sha256:abcdef123",
+					},
+				}
+
+				image2 := &v1alpha1.Image{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-image-2",
+						Namespace: defaultNamespace,
+					},
+					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
+						Status: corev1alpha1.Status{
+							Conditions: []corev1alpha1.Condition{
+								{
+									Type:   corev1alpha1.ConditionReady,
+									Status: corev1.ConditionUnknown,
+								},
+							},
+						},
+						LatestImage: "test-registry.io/test-image-2@sha256:abcdef123",
+					},
+				}
+
+				image3 := &v1alpha1.Image{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-image-3",
+						Namespace: defaultNamespace,
+					},
+					Spec: v1alpha1.ImageSpec{},
+					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
+						Status: corev1alpha1.Status{
+							Conditions: []corev1alpha1.Condition{
+								{
+									Type:   corev1alpha1.ConditionReady,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						},
+						LatestImage: "test-registry.io/test-image-3@sha256:abcdef123",
+					},
+				}
+
+				notDefaultNamespaceImage := &v1alpha1.Image{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-image-4",
+						Namespace: "not-default-namespace",
+					},
+					Status: v1alpha1.ImageStatus{
+						LatestBuildReason: "COMMIT",
+						Status: corev1alpha1.Status{
+							Conditions: []corev1alpha1.Condition{
+								{
+									Type:   corev1alpha1.ConditionReady,
+									Status: corev1.ConditionFalse,
+								},
+							},
+						},
+						LatestImage: "test-registry.io/test-image-4@sha256:abcdef123",
+					},
+				}
+
+				testhelpers.CommandTest{
+					Objects: []runtime.Object{
+						image1,
+						image2,
+						image3,
+						notDefaultNamespaceImage,
+					},
+					Args: []string{"-A"},
+					ExpectedOutput: `NAME            READY      LATEST REASON    LATEST IMAGE                                      NAMESPACE
+test-image-1    False      COMMIT           test-registry.io/test-image-1@sha256:abcdef123    some-default-namespace
+test-image-2    Unknown    COMMIT           test-registry.io/test-image-2@sha256:abcdef123    some-default-namespace
+test-image-3    True       COMMIT           test-registry.io/test-image-3@sha256:abcdef123    some-default-namespace
+test-image-4    False      COMMIT           test-registry.io/test-image-4@sha256:abcdef123    not-default-namespace
 
 `,
 				}.TestKpack(t, cmdFunc)


### PR DESCRIPTION
* Add 'LATEST_REASON','NAMESPACE' to 'kp image list' command
* Add --all-namespaces flag to 'kp image list' command
* Add --filter flag to 'kp image list' command

As discussed, the final criteria in the [0004-image-filter](https://github.com/pivotal/kpack/blob/master/rfcs/0004-image-filter.md) RFC was not completed as part of this PR. It was broken out into its own issue: https://github.com/vmware-tanzu/kpack-cli/issues/141