### PR TITLE
Migrate current descriptor api version to v1alpha3

### DIFF
--- a/pkg/import/dependency_descriptor.go
+++ b/pkg/import/dependency_descriptor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const CurrentAPIVersion = "kp.kpack.io/v1alpha2"
+const CurrentAPIVersion = "kp.kpack.io/v1alpha3"
 
 type API struct {
 	Version string `yaml:"apiVersion" json:"apiVersion"`
@@ -81,7 +81,7 @@ func (d DependencyDescriptor) Validate() error {
 		}
 	}
 
-	if _, ok := stackSet[d.DefaultClusterStack]; !ok {
+	if _, ok := stackSet[d.DefaultClusterStack]; !ok && d.DefaultClusterStack != "" {
 		return errors.Errorf("default cluster stack '%s' not found", d.DefaultClusterStack)
 	}
 
@@ -101,7 +101,7 @@ func (d DependencyDescriptor) Validate() error {
 		}
 	}
 
-	if _, ok := ccbSet[d.DefaultClusterBuilder]; !ok {
+	if _, ok := ccbSet[d.DefaultClusterBuilder]; !ok && d.DefaultClusterBuilder != "" {
 		return errors.Errorf("default cluster builder '%s' not found", d.DefaultClusterBuilder)
 	}
 

--- a/pkg/import/dependency_descriptor_test.go
+++ b/pkg/import/dependency_descriptor_test.go
@@ -106,11 +106,27 @@ func testDescriptor(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("the default cb does not exist", func() {
-			desc.DefaultClusterStack = "does-not-exist"
+		when("there is no default clusterstack", func() {
+			desc.DefaultClusterStack = ""
+
+			it("validates successfully", func() {
+				require.NoError(t, desc.Validate())
+			})
+		})
+
+		when("the default clusterbuilder does not exist", func() {
+			desc.DefaultClusterBuilder = "does-not-exist"
 
 			it("fails validation", func() {
 				require.Error(t, desc.Validate())
+			})
+		})
+
+		when("there is no default clusterbuilder", func() {
+			desc.DefaultClusterBuilder = ""
+
+			it("validates successfully", func() {
+				require.NoError(t, desc.Validate())
 			})
 		})
 


### PR DESCRIPTION
 - No meaningful descriptors with v1alpha1 were released
 - Allow DefaultClusterStack/DefaultClusterBuilder to not be set
 - This will allow descriptors to be published @ v1alpha3 without a DefaultClusterStack/DefaultClusterBuilder