### PR TITLE
Add Lifecycle image support for `kp import`

### DIFF
--- a/cmd/kp/main.go
+++ b/cmd/kp/main.go
@@ -211,8 +211,8 @@ func getStoreCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 
 func getLifecycleCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	lifecycleRootCommand := &cobra.Command{
-		Use:     "lifecycle",
-		Short:   "Lifecycle Commands",
+		Use:   "lifecycle",
+		Short: "Lifecycle Commands",
 	}
 	lifecycleRootCommand.AddCommand(
 		lifecycle.NewUpdateCommand(clientSetProvider, registry.DefaultUtilProvider{}),

--- a/pkg/commands/command_helper.go
+++ b/pkg/commands/command_helper.go
@@ -224,6 +224,7 @@ func getTypeToGVKLookup() map[reflect.Type]schema.GroupVersionKind {
 	return map[reflect.Type]schema.GroupVersionKind{
 		reflect.TypeOf(&v1.Secret{}):               v1GV.WithKind("Secret"),
 		reflect.TypeOf(&v1.ServiceAccount{}):       v1GV.WithKind("ServiceAccount"),
+		reflect.TypeOf(&v1.ConfigMap{}):            v1GV.WithKind("ConfigMap"),
 		reflect.TypeOf(&v1alpha1.Image{}):          buildGV.WithKind("Image"),
 		reflect.TypeOf(&v1alpha1.Builder{}):        buildGV.WithKind(v1alpha1.BuilderKind),
 		reflect.TypeOf(&v1alpha1.ClusterStack{}):   buildGV.WithKind(v1alpha1.ClusterStackKind),

--- a/pkg/commands/import/testdata/deps.yaml
+++ b/pkg/commands/import/testdata/deps.yaml
@@ -2,6 +2,8 @@ apiVersion: kp.kpack.io/v1alpha3
 kind: DependencyDescriptor
 defaultClusterBuilder: clusterbuilder-name
 defaultClusterStack: stack-name
+lifecycle:
+  image: some-registry.io/repo/lifecycle-image
 clusterStores:
 - name: store-name
   sources:

--- a/pkg/commands/import/testdata/updated-deps.yaml
+++ b/pkg/commands/import/testdata/updated-deps.yaml
@@ -2,6 +2,8 @@ apiVersion: kp.kpack.io/v1alpha3
 kind: DependencyDescriptor
 defaultClusterBuilder: clusterbuilder-name
 defaultClusterStack: stack-name
+lifecycle:
+  image: some-registry.io/repo/another-lifecycle-image
 clusterStores:
 - name: store-name
   sources:

--- a/pkg/commands/lifecycle/update_test.go
+++ b/pkg/commands/lifecycle/update_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020-Present VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package lifecycle_test
 
 import (
@@ -22,6 +25,7 @@ func TestUpdateCommand(t *testing.T) {
 
 func testUpdateCommand(t *testing.T, when spec.G, it spec.S) {
 
+	fakeRelocator := &registryfakes.Relocator{}
 	fakeRegistryUtilProvider := &registryfakes.UtilProvider{
 		FakeFetcher: registryfakes.NewLifecycleImageFetcher(
 			registryfakes.LifecycleInfo{
@@ -32,7 +36,7 @@ func testUpdateCommand(t *testing.T, when spec.G, it spec.S) {
 				},
 			},
 		),
-		FakeRelocator: &registryfakes.Relocator{},
+		FakeRelocator: fakeRelocator,
 	}
 
 	cmdFunc := func(k8sClient *fake.Clientset) *cobra.Command {
@@ -58,10 +62,84 @@ func testUpdateCommand(t *testing.T, when spec.G, it spec.S) {
 		Data: map[string]string{},
 	}
 
-	it("updates lifecycle-image ConfigMap", func() {
-		updatedLifecycleImageConfig := lifecycleImageConfig.DeepCopy()
-		updatedLifecycleImageConfig.Data["image"] = "canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest"
+	updatedLifecycleImageConfig := lifecycleImageConfig.DeepCopy()
+	updatedLifecycleImageConfig.Data["image"] = "canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest"
 
+	it("errors when lifecycle-image configmap is not found", func() {
+		testhelpers.CommandTest{
+			Objects: []runtime.Object{
+				kpConfig,
+			},
+			Args: []string{
+				"--image", "some-registry.io/repo/lifecycle-image",
+			},
+			ExpectErr: true,
+			ExpectedOutput: `Updating lifecycle image...
+Error: configmap "lifecycle-image" not found in "kpack" namespace
+`,
+		}.TestK8s(t, cmdFunc)
+	})
+
+	it("errors when io.buildpacks.lifecycle.metadata label is not set on given image", func() {
+		fetcher := &registryfakes.Fetcher{}
+		fetcher.AddImage("some-registry.io/repo/image-without-metadata", registryfakes.NewFakeImage("some-digest"))
+		fakeRegistryUtilProvider.FakeFetcher = fetcher
+
+		testhelpers.CommandTest{
+			Objects: []runtime.Object{
+				kpConfig,
+				lifecycleImageConfig,
+			},
+			Args: []string{
+				"--image", "some-registry.io/repo/image-without-metadata",
+			},
+			ExpectErr: true,
+			ExpectedOutput: `Updating lifecycle image...
+Error: image missing lifecycle metadata
+`,
+		}.TestK8s(t, cmdFunc)
+	})
+
+	it("errors when kp-config configmap is not found", func() {
+		testhelpers.CommandTest{
+			Objects: []runtime.Object{
+				lifecycleImageConfig,
+			},
+			Args: []string{
+				"--image", "some-registry.io/repo/lifecycle-image",
+			},
+			ExpectErr: true,
+			ExpectedOutput: `Updating lifecycle image...
+Error: failed to get canonical repository: configmaps "kp-config" not found
+`,
+		}.TestK8s(t, cmdFunc)
+	})
+
+	it("errors when canonical.repository key is not found in kp-config configmap", func() {
+		badKpConfig := &corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "kp-config",
+				Namespace: "kpack",
+			},
+			Data: map[string]string{},
+		}
+
+		testhelpers.CommandTest{
+			Objects: []runtime.Object{
+				badKpConfig,
+				lifecycleImageConfig,
+			},
+			Args: []string{
+				"--image", "some-registry.io/repo/lifecycle-image",
+			},
+			ExpectErr: true,
+			ExpectedOutput: `Updating lifecycle image...
+Error: failed to get canonical repository: key "canonical.repository" not found in configmap "kp-config"
+`,
+		}.TestK8s(t, cmdFunc)
+	})
+
+	it("updates lifecycle-image ConfigMap", func() {
 		testhelpers.CommandTest{
 			Objects: []runtime.Object{
 				kpConfig,
@@ -75,70 +153,180 @@ func testUpdateCommand(t *testing.T, when spec.G, it spec.S) {
 					Object: updatedLifecycleImageConfig,
 				},
 			},
-			ExpectedOutput: `Updated lifecycle image
+			ExpectedOutput: `Updating lifecycle image...
+	Uploading 'canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest'
+Updated lifecycle image
 `,
 		}.TestK8s(t, cmdFunc)
 	})
 
-	it("errors when io.buildpacks.lifecycle.metadata label is not set on given image", func() {
-		fetcher := &registryfakes.Fetcher{}
-		fetcher.AddImage("some-registry.io/repo/image-without-metadata", registryfakes.NewFakeImage("some-digest"))
-		fakeRegistryUtilProvider.FakeFetcher = fetcher
+	when("output flag is used", func() {
+		it("can output in yaml format", func() {
+			const resourceYAML = `apiVersion: v1
+data:
+  image: canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: lifecycle-image
+  namespace: kpack
+`
 
-		testhelpers.CommandTest{
-			Args: []string{
-				"--image", "some-registry.io/repo/image-without-metadata",
-			},
-			ExpectErr: true,
-			ExpectedOutput: `Error: image missing lifecycle metadata
+			testhelpers.CommandTest{
+				Objects: []runtime.Object{
+					kpConfig,
+					lifecycleImageConfig,
+				},
+				Args: []string{
+					"--image", "some-registry.io/repo/lifecycle-image",
+					"--output", "yaml",
+				},
+				ExpectUpdates: []clientgotesting.UpdateActionImpl{
+					{
+						Object: updatedLifecycleImageConfig,
+					},
+				},
+				ExpectedOutput: resourceYAML,
+				ExpectedErrorOutput: `Updating lifecycle image...
+	Uploading 'canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest'
 `,
-		}.TestK8s(t, cmdFunc)
+			}.TestK8s(t, cmdFunc)
+		})
+
+		it("can output in json format", func() {
+			const resourceJSON = `{
+    "kind": "ConfigMap",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "lifecycle-image",
+        "namespace": "kpack",
+        "creationTimestamp": null
+    },
+    "data": {
+        "image": "canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest"
+    }
+}
+`
+
+			testhelpers.CommandTest{
+				Objects: []runtime.Object{
+					kpConfig,
+					lifecycleImageConfig,
+				},
+				Args: []string{
+					"--image", "some-registry.io/repo/lifecycle-image",
+					"--output", "json",
+				},
+				ExpectUpdates: []clientgotesting.UpdateActionImpl{
+					{
+						Object: updatedLifecycleImageConfig,
+					},
+				},
+				ExpectedOutput: resourceJSON,
+				ExpectedErrorOutput: `Updating lifecycle image...
+	Uploading 'canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest'
+`,
+			}.TestK8s(t, cmdFunc)
+		})
 	})
 
-	it("errors when kp-config configmap is not found", func() {
-		testhelpers.CommandTest{
-			Args: []string{
-				"--image", "some-registry.io/repo/lifecycle-image",
-			},
-			ExpectErr: true,
-			ExpectedOutput: `Error: failed to get canonical repository: configmaps "kp-config" not found
+	when("dry-run flag is used", func() {
+		fakeRelocator.SetSkip(true)
+
+		it("does not update lifecycle-image configmap and prints result with dry run indicated", func() {
+			testhelpers.CommandTest{
+				Objects: []runtime.Object{
+					kpConfig,
+					lifecycleImageConfig,
+				},
+				Args: []string{
+					"--image", "some-registry.io/repo/lifecycle-image",
+					"--dry-run",
+				},
+				ExpectedOutput: `Updating lifecycle image... (dry run)
+	Skipping 'canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest'
+Updated lifecycle image (dry run)
 `,
-		}.TestK8s(t, cmdFunc)
+			}.TestK8s(t, cmdFunc)
+		})
+
+		when("output flag is used", func() {
+			it("does not update lifecycle-image configmap and prints the resource output", func() {
+				const resourceYAML = `apiVersion: v1
+data:
+  image: canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: lifecycle-image
+  namespace: kpack
+`
+
+				testhelpers.CommandTest{
+					Objects: []runtime.Object{
+						kpConfig,
+						lifecycleImageConfig,
+					},
+					Args: []string{
+						"--image", "some-registry.io/repo/lifecycle-image",
+						"--dry-run",
+						"--output", "yaml",
+					},
+					ExpectedOutput: resourceYAML,
+					ExpectedErrorOutput: `Updating lifecycle image... (dry run)
+	Skipping 'canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest'
+`,
+				}.TestK8s(t, cmdFunc)
+			})
+		})
 	})
 
-	it("errors when canonical.repository key is not found in kp-config configmap", func() {
-		badConfig := &corev1.ConfigMap{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      "kp-config",
-				Namespace: "kpack",
-			},
-			Data: map[string]string{},
-		}
-
-		testhelpers.CommandTest{
-			Objects: []runtime.Object{
-				badConfig,
-			},
-			Args: []string{
-				"--image", "some-registry.io/repo/lifecycle-image",
-			},
-			ExpectErr: true,
-			ExpectedOutput: `Error: failed to get canonical repository: key "canonical.repository" not found in configmap "kp-config"
+	when("dry-run-with-image-upload flag is used", func() {
+		it("does not update lifecycle-image configmap and prints result with dry run indicated", func() {
+			testhelpers.CommandTest{
+				Objects: []runtime.Object{
+					kpConfig,
+					lifecycleImageConfig,
+				},
+				Args: []string{
+					"--image", "some-registry.io/repo/lifecycle-image",
+					"--dry-run-with-image-upload",
+				},
+				ExpectedOutput: `Updating lifecycle image... (dry run with image upload)
+	Uploading 'canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest'
+Updated lifecycle image (dry run with image upload)
 `,
-		}.TestK8s(t, cmdFunc)
-	})
+			}.TestK8s(t, cmdFunc)
+		})
 
-	it("errors when lifecycle-image configmap is not found", func() {
-		testhelpers.CommandTest{
-			Objects: []runtime.Object{
-				kpConfig,
-			},
-			Args: []string{
-				"--image", "some-registry.io/repo/lifecycle-image",
-			},
-			ExpectErr: true,
-			ExpectedOutput: `Error: configmap "lifecycle-image" not found in "kpack" namespace
+		when("output flag is used", func() {
+			it("does not update lifecycle-image configmap and prints the resource output", func() {
+				const resourceYAML = `apiVersion: v1
+data:
+  image: canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: lifecycle-image
+  namespace: kpack
+`
+
+				testhelpers.CommandTest{
+					Objects: []runtime.Object{
+						kpConfig,
+						lifecycleImageConfig,
+					},
+					Args: []string{
+						"--image", "some-registry.io/repo/lifecycle-image",
+						"--dry-run-with-image-upload",
+						"--output", "yaml",
+					},
+					ExpectedOutput: resourceYAML,
+					ExpectedErrorOutput: `Updating lifecycle image... (dry run with image upload)
+	Uploading 'canonical-registry.io/canonical-repo/lifecycle@sha256:lifecycle-image-digest'
 `,
-		}.TestK8s(t, cmdFunc)
+				}.TestK8s(t, cmdFunc)
+			})
+		})
 	})
 }

--- a/pkg/import/change_summarizer.go
+++ b/pkg/import/change_summarizer.go
@@ -1,0 +1,77 @@
+package _import
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pivotal/build-service-cli/pkg/clusterstack"
+	"github.com/pivotal/build-service-cli/pkg/clusterstore"
+	buildk8s "github.com/pivotal/build-service-cli/pkg/k8s"
+)
+
+func SummarizeChange(
+	desc DependencyDescriptor,
+	storeFactory *clusterstore.Factory, stackFactory *clusterstack.Factory,
+	differ Differ, cs buildk8s.ClientSet) (hasChanges bool, changes string, err error) {
+
+	var summarizer changeSummarizer
+	iDiffer := &ImportDiffer{
+		Differ:         differ,
+		StoreRefGetter: storeFactory,
+		StackRefGetter: stackFactory,
+	}
+
+	err = writeLifecycleChange(desc.Lifecycle, iDiffer, cs, &summarizer)
+	if err != nil {
+		return
+	}
+
+	err = writeClusterStoresChange(desc.ClusterStores, iDiffer, cs, &summarizer)
+	if err != nil {
+		return
+	}
+
+	err = writeClusterStacksChange(desc.GetClusterStacks(), iDiffer, cs, &summarizer)
+	if err != nil {
+		return
+	}
+
+	err = writeClusterBuildersChange(desc.GetClusterBuilders(), iDiffer, cs, &summarizer)
+	if err != nil {
+		return
+	}
+
+	return summarizer.hasChanges, summarizer.changes.String(), nil
+}
+
+type changeSummarizer struct {
+	hasChanges bool
+	changes    strings.Builder
+	diffs      strings.Builder
+}
+
+func (cs *changeSummarizer) writeChange(header string) {
+	if cs.changes.Len() == 0 {
+		cs.changes.WriteString("Changes\n\n")
+	}
+
+	cs.changes.WriteString(fmt.Sprintf("%s\n\n", header))
+
+	change := cs.diffs.String()
+	if change == "" {
+		cs.changes.WriteString("No Changes\n\n")
+	} else {
+		cs.changes.WriteString(change)
+		cs.hasChanges = true
+	}
+
+	cs.diffs.Reset()
+}
+
+func (cs *changeSummarizer) writeDiff(diff string) error {
+	var err error
+	if diff != "" {
+		_, err = cs.diffs.WriteString(fmt.Sprintf("%s\n\n", diff))
+	}
+	return err
+}

--- a/pkg/import/change_writer.go
+++ b/pkg/import/change_writer.go
@@ -1,0 +1,104 @@
+package _import
+
+import (
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	buildk8s "github.com/pivotal/build-service-cli/pkg/k8s"
+	"github.com/pivotal/build-service-cli/pkg/lifecycle"
+)
+
+type changeWriter interface {
+	writeDiff(diffs string) error
+	writeChange(header string)
+}
+
+func writeLifecycleChange(newLifecycle Lifecycle, differ *ImportDiffer, cs buildk8s.ClientSet, cw changeWriter) error {
+	if newLifecycle.Image != "" {
+		oldImg, err := lifecycle.GetImage(cs.K8sClient)
+		if err != nil {
+			return err
+		}
+
+		diff, err := differ.DiffLifecycle(oldImg, newLifecycle.Image)
+		if err != nil {
+			return err
+		}
+
+		if err = cw.writeDiff(diff); err != nil {
+			return err
+		}
+	}
+
+	cw.writeChange("Lifecycle")
+	return nil
+}
+
+func writeClusterStoresChange(stores []ClusterStore, differ *ImportDiffer, cs buildk8s.ClientSet, cw changeWriter) error {
+	for _, store := range stores {
+		oldStore, err := cs.KpackClient.KpackV1alpha1().ClusterStores().Get(store.Name, metav1.GetOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+		if k8serrors.IsNotFound(err) {
+			oldStore = nil
+		}
+
+		diff, err := differ.DiffClusterStore(oldStore, store)
+		if err != nil {
+			return err
+		}
+		if err = cw.writeDiff(diff); err != nil {
+			return err
+		}
+	}
+
+	cw.writeChange("ClusterStores")
+	return nil
+}
+
+func writeClusterStacksChange(stacks []ClusterStack, differ *ImportDiffer, cs buildk8s.ClientSet, cw changeWriter) error {
+	for _, stack := range stacks {
+		oldStack, err := cs.KpackClient.KpackV1alpha1().ClusterStacks().Get(stack.Name, metav1.GetOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+		if k8serrors.IsNotFound(err) {
+			oldStack = nil
+		}
+
+		diff, err := differ.DiffClusterStack(oldStack, stack)
+		if err != nil {
+			return err
+		}
+		if err = cw.writeDiff(diff); err != nil {
+			return err
+		}
+	}
+
+	cw.writeChange("ClusterStacks")
+	return nil
+}
+
+func writeClusterBuildersChange(builders []ClusterBuilder, differ *ImportDiffer, cs buildk8s.ClientSet, cw changeWriter) error {
+	for _, builder := range builders {
+		oldBuilder, err := cs.KpackClient.KpackV1alpha1().ClusterBuilders().Get(builder.Name, metav1.GetOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+		if k8serrors.IsNotFound(err) {
+			oldBuilder = nil
+		}
+
+		diff, err := differ.DiffClusterBuilder(oldBuilder, builder)
+		if err != nil {
+			return err
+		}
+		if err = cw.writeDiff(diff); err != nil {
+			return err
+		}
+	}
+
+	cw.writeChange("ClusterBuilders")
+	return nil
+}

--- a/pkg/import/dependency_descriptor.go
+++ b/pkg/import/dependency_descriptor.go
@@ -20,18 +20,21 @@ type DependencyDescriptor struct {
 	Kind                  string           `yaml:"kind"`
 	DefaultClusterStack   string           `yaml:"defaultClusterStack"`
 	DefaultClusterBuilder string           `yaml:"defaultClusterBuilder"`
+	Lifecycle             Lifecycle        `yaml:"lifecycle"`
 	ClusterStores         []ClusterStore   `yaml:"clusterStores"`
 	ClusterStacks         []ClusterStack   `yaml:"clusterStacks"`
 	ClusterBuilders       []ClusterBuilder `yaml:"clusterBuilders"`
 }
 
+type Source struct {
+	Image string `yaml:"image"`
+}
+
+type Lifecycle Source
+
 type ClusterStore struct {
 	Name    string   `yaml:"name"`
 	Sources []Source `yaml:"sources"`
-}
-
-type Source struct {
-	Image string `yaml:"image"`
 }
 
 type ClusterStack struct {
@@ -106,6 +109,14 @@ func (d DependencyDescriptor) Validate() error {
 	}
 
 	return nil
+}
+
+func (d DependencyDescriptor) GetLifecycleImage() string {
+	return d.Lifecycle.Image
+}
+
+func (d DependencyDescriptor) HasLifecycleImage() bool {
+	return d.Lifecycle.Image != ""
 }
 
 func (d DependencyDescriptor) GetClusterStacks() []ClusterStack {

--- a/pkg/import/import_differ.go
+++ b/pkg/import/import_differ.go
@@ -27,6 +27,10 @@ type ImportDiffer struct {
 	StackRefGetter StackRefGetter
 }
 
+func (id *ImportDiffer) DiffLifecycle(oldImg string, newImg string) (string, error) {
+	return id.Differ.Diff(oldImg, newImg)
+}
+
 func (id *ImportDiffer) DiffClusterStore(oldCS *v1alpha1.ClusterStore, newCS ClusterStore) (string, error) {
 	type void struct{}
 	newBPs := map[string]void{}

--- a/pkg/lifecycle/config_helper.go
+++ b/pkg/lifecycle/config_helper.go
@@ -1,0 +1,35 @@
+package lifecycle
+
+import (
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+const (
+	lifecycleNamespace     = "kpack"
+	lifecycleConfigMapName = "lifecycle-image"
+	lifecycleImageKey      = "image"
+)
+
+func GetImage(c k8s.Interface) (string, error) {
+	cm, err := getConfigMap(c)
+	if err != nil {
+		return "", err
+	}
+	return cm.Data[lifecycleImageKey], err
+}
+
+func getConfigMap(c k8s.Interface) (*v1.ConfigMap, error) {
+	cm, err := c.CoreV1().ConfigMaps(lifecycleNamespace).Get(lifecycleConfigMapName, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		err = errors.Errorf("configmap %q not found in %q namespace", lifecycleConfigMapName, lifecycleNamespace)
+	}
+	return cm, err
+}
+
+func updateConfigMap(cm *v1.ConfigMap, c k8s.Interface) (*v1.ConfigMap, error) {
+	return c.CoreV1().ConfigMaps(lifecycleNamespace).Update(cm)
+}

--- a/pkg/lifecycle/image_updater.go
+++ b/pkg/lifecycle/image_updater.go
@@ -1,0 +1,84 @@
+package lifecycle
+
+import (
+	"io"
+	"path"
+
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/pivotal/kpack/pkg/registry/imagehelpers"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+
+	buildk8s "github.com/pivotal/build-service-cli/pkg/k8s"
+	"github.com/pivotal/build-service-cli/pkg/registry"
+)
+
+const (
+	lifecycleImageName     = "lifecycle"
+	lifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
+)
+
+type PreUpdateHook func(*corev1.ConfigMap)
+
+type ImageUpdaterConfig struct {
+	DryRun       bool
+	IOWriter     io.Writer
+	ImgFetcher   registry.Fetcher
+	ImgRelocator registry.Relocator
+	ClientSet    buildk8s.ClientSet
+	TLSConfig    registry.TLSConfig
+}
+
+func UpdateImage(srcImgLocation string, cfg ImageUpdaterConfig, hooks ...PreUpdateHook) (*corev1.ConfigMap, error) {
+	cm, err := getConfigMap(cfg.ClientSet.K8sClient)
+	if err != nil {
+		return cm, err
+	}
+
+	img, err := cfg.ImgFetcher.Fetch(srcImgLocation, cfg.TLSConfig)
+	if err != nil {
+		return cm, err
+	}
+
+	if err = validateImage(img); err != nil {
+		return cm, err
+	}
+
+	relocatedImgTag, err := relocateImageToCanonicalRepo(img, cfg)
+	if err != nil {
+		return cm, err
+	}
+
+	cm.Data[lifecycleImageKey] = relocatedImgTag
+
+	for _, h := range hooks {
+		h(cm)
+	}
+
+	if !cfg.DryRun {
+		cm, err = updateConfigMap(cm, cfg.ClientSet.K8sClient)
+	}
+	return cm, err
+}
+
+func validateImage(img ggcrv1.Image) error {
+	hasLabel, err := imagehelpers.HasLabel(img, lifecycleMetadataLabel)
+	if err != nil {
+		return err
+	}
+
+	if !hasLabel {
+		return errors.New("image missing lifecycle metadata")
+	}
+	return nil
+}
+
+func relocateImageToCanonicalRepo(img ggcrv1.Image, cfg ImageUpdaterConfig) (string, error) {
+	canonicalRepo, err := buildk8s.DefaultConfigHelper(cfg.ClientSet).GetCanonicalRepository()
+	if err != nil {
+		return "", err
+	}
+
+	dstImgLocation := path.Join(canonicalRepo, lifecycleImageName)
+	return cfg.ImgRelocator.Relocate(img, dstImgLocation, cfg.IOWriter, cfg.TLSConfig)
+}


### PR DESCRIPTION
- Pulled out shared functionality between `kp lifecycle update` amd `kp import` into `pkg/lifecycle`

Issue: https://github.com/vmware-tanzu/kpack-cli/issues/143