### PR TITLE
Add image configured builder to image status command

### DIFF
--- a/pkg/commands/image/status.go
+++ b/pkg/commands/image/status.go
@@ -71,6 +71,8 @@ func displayImageStatus(cmd *cobra.Command, image *v1alpha1.Image, builds []v1al
 		"Status", imgDetails.status,
 		"Message", imgDetails.message,
 		"LatestImage", imgDetails.latestImage,
+		"BuilderKind", image.Spec.Builder.Kind,
+		"BuilderName", image.Spec.Builder.Name,
 	)
 	if err != nil {
 		return err

--- a/pkg/commands/image/status_test.go
+++ b/pkg/commands/image/status_test.go
@@ -46,6 +46,12 @@ func testImageStatusCommand(t *testing.T, when spec.G, it spec.S) {
 						Name:      imageName,
 						Namespace: namespace,
 					},
+					Spec: v1alpha1.ImageSpec{
+						Builder: corev1.ObjectReference{
+							Kind: "ClusterBuilder",
+							Name: "some-cluster-builder",
+						},
+					},
 					Status: v1alpha1.ImageStatus{
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
@@ -62,6 +68,8 @@ func testImageStatusCommand(t *testing.T, when spec.G, it spec.S) {
 				const expectedOutput = `Status:         Not Ready
 Message:        --
 LatestImage:    test-registry.io/test-image-1@sha256:abcdef123
+BuilderKind:    ClusterBuilder
+BuilderName:    some-cluster-builder
 
 Last Successful Build
 Id:              1
@@ -101,6 +109,12 @@ Build Reason:    COMMIT,BUILDPACK
 						Name:      imageName,
 						Namespace: defaultNamespace,
 					},
+					Spec: v1alpha1.ImageSpec{
+						Builder: corev1.ObjectReference{
+							Kind: "ClusterBuilder",
+							Name: "some-cluster-builder",
+						},
+					},
 					Status: v1alpha1.ImageStatus{
 						Status: corev1alpha1.Status{
 							Conditions: []corev1alpha1.Condition{
@@ -117,6 +131,8 @@ Build Reason:    COMMIT,BUILDPACK
 				const expectedOutput = `Status:         Not Ready
 Message:        --
 LatestImage:    test-registry.io/test-image-1@sha256:abcdef123
+BuilderKind:    ClusterBuilder
+BuilderName:    some-cluster-builder
 
 Last Successful Build
 Id:              1


### PR DESCRIPTION
https://github.com/vmware-tanzu/kpack-cli/issues/156

This is showing just the configured builder, not guaranteed to be the builder used to create the latest image. I think this might be fine temporarily before we make api changes.