### PR TITLE
Zero out mod time

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -10,6 +10,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
+)
+
+var (
+	normalizedTime = time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)
 )
 
 func CreateTar(path string) (string, error) {
@@ -126,4 +131,6 @@ func finalizeHeader(header *tar.Header, uid, gid int, mode int64) {
 	header.Gid = gid
 	header.Uname = ""
 	header.Gname = ""
+
+	header.ModTime = normalizedTime
 }

--- a/pkg/commands/clusterbuilder/create_test.go
+++ b/pkg/commands/clusterbuilder/create_test.go
@@ -103,7 +103,7 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it("creates a ClusterBuilder", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
 			},
 			Args: []string{
@@ -128,7 +128,7 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 		expectedBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","creationTimestamp":null},"spec":{"tag":"some-registry/some-project/test-builder","stack":{"kind":"ClusterStack","name":"default"},"store":{"kind":"ClusterStore","name":"default"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
 			},
 			Args: []string{
@@ -146,7 +146,7 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it("creates a ClusterBuilder with the canonical tag when tag is not specified", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
 			},
 			Args: []string{
@@ -188,7 +188,7 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 		}
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				badConfig,
 			},
 			Args: []string{
@@ -216,7 +216,7 @@ func testClusterBuilderCreateCommand(t *testing.T, when spec.G, it spec.S) {
 		}
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				badConfig,
 			},
 			Args: []string{
@@ -261,7 +261,7 @@ status:
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -328,7 +328,7 @@ status:
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -350,7 +350,7 @@ status:
 	when("dry-run flag is used", func() {
 		it("does not create a ClusterBuilder and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -396,7 +396,7 @@ status:
 
 			it("does not create a ClusterBuilder and prints the resource output", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -443,7 +443,7 @@ status:
 			expectedBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","creationTimestamp":null},"spec":{"tag":"some-registry/some-project/test-builder","stack":{"kind":"ClusterStack","name":"some-stack"},"store":{"kind":"ClusterStore","name":"some-store"},"order":[{"group":[{"id":"org.cloudfoundry.go"},{"id":"org.cloudfoundry.nodejs","version":"1"},{"id":"org.cloudfoundry.ruby","version":"1.2.3"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -465,7 +465,7 @@ status:
 		when("buildpack and order flags are used together", func() {
 			it("returns an error", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{

--- a/pkg/commands/clusterbuilder/save_test.go
+++ b/pkg/commands/clusterbuilder/save_test.go
@@ -104,7 +104,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 	when("creating", func() {
 		it("creates a ClusterBuilder when it does not exist", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -129,7 +129,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 			builder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"test-builder","creationTimestamp":null},"spec":{"tag":"some-registry/some-project/test-builder","stack":{"kind":"ClusterStack","name":"default"},"store":{"kind":"ClusterStore","name":"default"},"order":[{"group":[{"id":"org.cloudfoundry.nodejs"}]},{"group":[{"id":"org.cloudfoundry.go"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -147,7 +147,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it("creates a ClusterBuilder with the canonical tag when tag is not specified", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -185,7 +185,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -206,7 +206,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it("returns error when buildpack and order flags are used together", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -244,7 +244,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					badConfig,
 				},
 				Args: []string{
@@ -272,7 +272,7 @@ func testClusterBuilderSaveCommand(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					badConfig,
 				},
 				Args: []string{
@@ -317,7 +317,7 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -384,7 +384,7 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -406,7 +406,7 @@ status:
 		when("dry-run flag is used", func() {
 			it("does not create a ClusterBuilder and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -452,7 +452,7 @@ status:
 
 				it("does not create a ClusterBuilder and prints the resource output", func() {
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
 						},
 						Args: []string{
@@ -474,7 +474,7 @@ status:
 	when("patching", func() {
 		it("patches when the ClusterBuilder does exist", func() {
 			testhelpers.CommandTest{
-				KpackObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					builder,
 				},
 				Args: []string{
@@ -495,7 +495,7 @@ status:
 
 		it("does not patch if there are no changes", func() {
 			testhelpers.CommandTest{
-				KpackObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					builder,
 				},
 				Args: []string{
@@ -536,7 +536,7 @@ status:
 `
 
 				testhelpers.CommandTest{
-					KpackObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						builder,
 					},
 					Args: []string{
@@ -603,7 +603,7 @@ status:
 `
 
 				testhelpers.CommandTest{
-					KpackObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						builder,
 					},
 					Args: []string{
@@ -651,7 +651,7 @@ status:
 `
 
 					testhelpers.CommandTest{
-						KpackObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							builder,
 						},
 						Args: []string{
@@ -667,7 +667,7 @@ status:
 		when("dry-run flag is used", func() {
 			it("does not patch a ClusterBuilder and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					KpackObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						builder,
 					},
 					Args: []string{
@@ -686,7 +686,7 @@ status:
 			when("there are no changes in the patch", func() {
 				it("does not patch and informs of no change", func() {
 					testhelpers.CommandTest{
-						KpackObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							builder,
 						},
 						Args: []string{
@@ -729,7 +729,7 @@ status:
 `
 
 					testhelpers.CommandTest{
-						KpackObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							builder,
 						},
 						Args: []string{

--- a/pkg/commands/clusterstack/create_test.go
+++ b/pkg/commands/clusterstack/create_test.go
@@ -88,7 +88,7 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it("creates a stack", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
 			},
 			Args: []string{
@@ -133,7 +133,7 @@ ClusterStack "stack-name" created
 		}
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				badConfig,
 			},
 			Args: []string{
@@ -165,7 +165,7 @@ status:
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -211,7 +211,7 @@ Uploading to 'canonical-registry.io/canonical-repo'...
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -238,7 +238,7 @@ Uploading to 'canonical-registry.io/canonical-repo'...
 
 		it("does not create a clusterstack and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -276,7 +276,7 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -300,7 +300,7 @@ Uploading to 'canonical-registry.io/canonical-repo'... (dry run)
 	when("dry-run-with-image-upload flag is used", func() {
 		it("does not create a clusterstack and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -337,7 +337,7 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{

--- a/pkg/commands/clusterstack/save_test.go
+++ b/pkg/commands/clusterstack/save_test.go
@@ -90,7 +90,7 @@ func testSaveCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it("creates a stack", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -135,7 +135,7 @@ ClusterStack "stack-name" created
 			}
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					badConfig,
 				},
 				Args: []string{
@@ -167,7 +167,7 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -213,7 +213,7 @@ Uploading to 'canonical-registry.io/canonical-repo'...
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -240,7 +240,7 @@ Uploading to 'canonical-registry.io/canonical-repo'...
 
 			it("does not create a clusterstack and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -278,7 +278,7 @@ status:
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
 						},
 						Args: []string{
@@ -302,7 +302,7 @@ Uploading to 'canonical-registry.io/canonical-repo'... (dry run)
 		when("dry-run-with-image-upload flag is used", func() {
 			it("does not create a clusterstack and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -339,7 +339,7 @@ status:
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
 						},
 						Args: []string{
@@ -436,10 +436,8 @@ Uploading to 'canonical-registry.io/canonical-repo'... (dry run with image uploa
 				Status: stack.Status,
 			}
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -479,10 +477,8 @@ ClusterStack "stack-name" updated
 			})
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -503,7 +499,7 @@ ClusterStack "stack-name" updated (no change)
 
 		it("returns error when kp-config configmap is not found", func() {
 			testhelpers.CommandTest{
-				KpackObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -526,10 +522,8 @@ ClusterStack "stack-name" updated (no change)
 			}
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					badConfig,
-				},
-				KpackObjects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -566,10 +560,8 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						stack,
 					},
 					Args: []string{
@@ -636,10 +628,8 @@ Uploading to 'canonical-registry.io/canonical-repo'...
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						stack,
 					},
 					Args: []string{
@@ -710,10 +700,8 @@ status:
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							stack,
 						},
 						Args: []string{
@@ -739,10 +727,8 @@ Build and Run images already exist in stack
 
 			it("does not update the clusterstack and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						stack,
 					},
 					Args: []string{
@@ -785,10 +771,8 @@ status:
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							stack,
 						},
 						Args: []string{
@@ -812,10 +796,8 @@ Uploading to 'canonical-registry.io/canonical-repo'... (dry run)
 		when("dry-run--with-image-upload flag is used", func() {
 			it("does not update the clusterstack and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						stack,
 					},
 					Args: []string{
@@ -857,10 +839,8 @@ status:
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							stack,
 						},
 						Args: []string{

--- a/pkg/commands/clusterstack/update_test.go
+++ b/pkg/commands/clusterstack/update_test.go
@@ -1,5 +1,6 @@
 // Copyright 2020-Present VMware, Inc.
-// SPDX-License-Identifier: Apache-2.0
+//
+//SPDX-License-Identifier: Apache-2.0
 
 package clusterstack_test
 
@@ -121,10 +122,8 @@ func testUpdateCommand(t *testing.T, when spec.G, it spec.S) {
 			Status: stack.Status,
 		}
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
-			},
-			KpackObjects: []runtime.Object{
 				stack,
 			},
 			Args: []string{
@@ -164,10 +163,8 @@ ClusterStack "stack-name" updated
 		})
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
-			},
-			KpackObjects: []runtime.Object{
 				stack,
 			},
 			Args: []string{
@@ -188,7 +185,7 @@ ClusterStack "stack-name" updated (no change)
 
 	it("returns error when kp-config configmap is not found", func() {
 		testhelpers.CommandTest{
-			KpackObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				stack,
 			},
 			Args: []string{
@@ -211,10 +208,8 @@ ClusterStack "stack-name" updated (no change)
 		}
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				badConfig,
-			},
-			KpackObjects: []runtime.Object{
 				stack,
 			},
 			Args: []string{
@@ -251,10 +246,8 @@ status:
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -321,10 +314,8 @@ Uploading to 'canonical-registry.io/canonical-repo'...
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -395,10 +386,8 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						stack,
 					},
 					Args: []string{
@@ -422,10 +411,8 @@ Build and Run images already exist in stack
 	when("dry-run flag is used", func() {
 		it("does not update the clusterstack and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -468,10 +455,8 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						stack,
 					},
 					Args: []string{
@@ -495,10 +480,8 @@ Uploading to 'canonical-registry.io/canonical-repo'... (dry run)
 	when("dry-run--with-image-upload flag is used", func() {
 		it("does not update the clusterstack and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					stack,
 				},
 				Args: []string{
@@ -540,10 +523,8 @@ status:
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						stack,
 					},
 					Args: []string{

--- a/pkg/commands/clusterstore/add_test.go
+++ b/pkg/commands/clusterstore/add_test.go
@@ -82,10 +82,8 @@ func testClusterStoreAddCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it("adds a buildpackage to store", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
-			},
-			KpackObjects: []runtime.Object{
 				existingStore,
 			},
 			Args: []string{
@@ -123,10 +121,8 @@ ClusterStore "store-name" updated
 
 	it("does not add buildpackage with the same digest", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
-			},
-			KpackObjects: []runtime.Object{
 				existingStore,
 			},
 			Args: []string{
@@ -144,10 +140,8 @@ ClusterStore "store-name" updated (no change)
 
 	it("errors when the provided store does not exist", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
-			},
-			KpackObjects: []runtime.Object{
 				existingStore,
 			},
 			Args: []string{
@@ -161,7 +155,7 @@ ClusterStore "store-name" updated (no change)
 
 	it("errors when kp-config configmap is not found", func() {
 		testhelpers.CommandTest{
-			KpackObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				existingStore,
 			},
 			Args: []string{
@@ -183,10 +177,8 @@ ClusterStore "store-name" updated (no change)
 		}
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				badConfig,
-			},
-			KpackObjects: []runtime.Object{
 				existingStore,
 			},
 			Args: []string{
@@ -214,10 +206,8 @@ status: {}
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					existingStore,
 				},
 				Args: []string{
@@ -277,10 +267,8 @@ status: {}
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					existingStore,
 				},
 				Args: []string{
@@ -327,10 +315,8 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -352,10 +338,8 @@ status: {}
 	when("dry-run flag is used", func() {
 		it("does not create a clusterstore and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					existingStore,
 				},
 				Args: []string{
@@ -378,10 +362,8 @@ ClusterStore "store-name" updated (dry run)
 		when("there are no changes in the update", func() {
 			it("does not create a clusterstore and informs of no change", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -415,10 +397,8 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -443,10 +423,8 @@ status: {}
 	when("dry-run-with-image-upload flag is used", func() {
 		it("does not create a clusterstore and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					existingStore,
 				},
 				Args: []string{
@@ -468,10 +446,8 @@ ClusterStore "store-name" updated (dry run with image upload)
 		when("there are no changes in the update", func() {
 			it("does not create a clusterstore and informs of no change", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -505,10 +481,8 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{

--- a/pkg/commands/clusterstore/create_test.go
+++ b/pkg/commands/clusterstore/create_test.go
@@ -86,7 +86,7 @@ func testClusterStoreCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it("creates a cluster store", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
 			},
 			Args: []string{
@@ -130,7 +130,7 @@ ClusterStore "store-name" created
 		}
 
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				badConfig,
 			},
 			Args: []string{
@@ -145,7 +145,7 @@ ClusterStore "store-name" created
 
 	it("fails when a buildpackage is not provided", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{
+			Objects: []runtime.Object{
 				config,
 			},
 			Args: []string{
@@ -173,7 +173,7 @@ status: {}
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -219,7 +219,7 @@ status: {}
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -243,7 +243,7 @@ status: {}
 	when("dry-run flag is used", func() {
 		it("does not create a clusterstore and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -278,7 +278,7 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -301,7 +301,7 @@ status: {}
 	when("dry-run-with-image-upload flag is used", func() {
 		it("does not create a clusterstore and prints result with dry run indicated", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -335,7 +335,7 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{

--- a/pkg/commands/clusterstore/save_test.go
+++ b/pkg/commands/clusterstore/save_test.go
@@ -89,7 +89,7 @@ func testClusterStoreSaveCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it("creates a cluster store", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -133,7 +133,7 @@ ClusterStore "store-name" created
 			}
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					badConfig,
 				},
 				Args: []string{
@@ -148,7 +148,7 @@ ClusterStore "store-name" created
 
 		it("fails when a buildpackage is not provided", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
 				},
 				Args: []string{
@@ -176,7 +176,7 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -222,7 +222,7 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -246,7 +246,7 @@ status: {}
 		when("dry-run flag is used", func() {
 			it("does not create a clusterstore and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -281,7 +281,7 @@ status: {}
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
 						},
 						Args: []string{
@@ -304,7 +304,7 @@ status: {}
 		when("dry-run-with-image-upload flag is used", func() {
 			it("does not create a clusterstore and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
 					},
 					Args: []string{
@@ -338,7 +338,7 @@ status: {}
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
 						},
 						Args: []string{
@@ -390,10 +390,8 @@ status: {}
 
 		it("adds a buildpackage to a store when it exists", func() {
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					config,
-				},
-				KpackObjects: []runtime.Object{
 					existingStore,
 				},
 				Args: []string{
@@ -445,10 +443,8 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -508,10 +504,8 @@ status: {}
 `
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -558,10 +552,8 @@ status: {}
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							existingStore,
 						},
 						Args: []string{
@@ -583,10 +575,8 @@ status: {}
 		when("dry-run flag is used", func() {
 			it("does not create a clusterstore and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -609,10 +599,8 @@ ClusterStore "store-name" updated (dry run)
 			when("there are no changes in the update", func() {
 				it("does not create a clusterstore and informs of no change", func() {
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							existingStore,
 						},
 						Args: []string{
@@ -646,10 +634,8 @@ status: {}
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							existingStore,
 						},
 						Args: []string{
@@ -674,10 +660,8 @@ status: {}
 		when("dry-run-with-image-upload flag is used", func() {
 			it("does not create a clusterstore and prints result with dry run indicated", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						config,
-					},
-					KpackObjects: []runtime.Object{
 						existingStore,
 					},
 					Args: []string{
@@ -699,10 +683,8 @@ ClusterStore "store-name" updated (dry run with image upload)
 			when("there are no changes in the update", func() {
 				it("does not create a clusterstore and informs of no change", func() {
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							existingStore,
 						},
 						Args: []string{
@@ -736,10 +718,8 @@ status: {}
 `
 
 					testhelpers.CommandTest{
-						K8sObjects: []runtime.Object{
+						Objects: []runtime.Object{
 							config,
-						},
-						KpackObjects: []runtime.Object{
 							existingStore,
 						},
 						Args: []string{

--- a/pkg/commands/import/import_test.go
+++ b/pkg/commands/import/import_test.go
@@ -244,7 +244,7 @@ func testImportCommand(t *testing.T, when spec.G, it spec.S) {
 			defaultBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null},"spec":{"tag":"canonical-registry.io/canonical-repo/default","stack":{"kind":"ClusterStack","name":"stack-name"},"store":{"kind":"ClusterStore","name":"store-name"},"order":[{"group":[{"id":"buildpack-id"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					kpConfig,
 					lifecycleImageConfig,
 				},
@@ -295,7 +295,7 @@ Imported resources
 			require.NoError(t, err)
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					kpConfig,
 					lifecycleImageConfig,
 				},
@@ -344,7 +344,7 @@ Imported resources
 			defaultBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null},"spec":{"tag":"canonical-registry.io/canonical-repo/default","stack":{"kind":"ClusterStack","name":"stack-name"},"store":{"kind":"ClusterStore","name":"store-name"},"order":[{"group":[{"id":"buildpack-id"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					kpConfig,
 					lifecycleImageConfig,
 				},
@@ -383,7 +383,7 @@ Imported resources
 				defaultBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null},"spec":{"tag":"canonical-registry.io/canonical-repo/default","stack":{"kind":"ClusterStack","name":"stack-name"},"store":{"kind":"ClusterStore","name":"store-name"},"order":[{"group":[{"id":"buildpack-id"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						kpConfig,
 						lifecycleImageConfig,
 					},
@@ -451,7 +451,7 @@ Imported resources
 				defaultBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null},"spec":{"tag":"canonical-registry.io/canonical-repo/default","stack":{"kind":"ClusterStack","name":"stack-name"},"store":{"kind":"ClusterStore","name":"store-name"},"order":[{"group":[{"id":"buildpack-id"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						kpConfig,
 						lifecycleImageConfig,
 					},
@@ -554,11 +554,9 @@ Imported resources
 				defaultStack.Spec.RunImage.Image = "some-uploaded-run-image@build-image-digest"
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						kpConfig,
 						lifecycleImageConfig,
-					},
-					KpackObjects: []runtime.Object{
 						store,
 						stack,
 						defaultStack,
@@ -613,11 +611,9 @@ Imported resources
 				expectedDefaultBuilder.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = `{"kind":"ClusterBuilder","apiVersion":"kpack.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null},"spec":{"tag":"canonical-registry.io/canonical-repo/default","stack":{"kind":"ClusterStack","name":"stack-name"},"store":{"kind":"ClusterStore","name":"store-name"},"order":[{"group":[{"id":"buildpack-id"}]}],"serviceAccountRef":{"namespace":"kpack","name":"some-serviceaccount"}},"status":{"stack":{}}}`
 
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						kpConfig,
 						lifecycleImageConfig,
-					},
-					KpackObjects: []runtime.Object{
 						store,
 						stack,
 						defaultStack,
@@ -714,11 +710,9 @@ Imported resources
 
 			it("creates stores, stacks, and cbs defined in the dependency descriptor and updates the timestamp", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						kpConfig,
 						lifecycleImageConfig,
-					},
-					KpackObjects: []runtime.Object{
 						store,
 						stack,
 						defaultStack,
@@ -760,7 +754,7 @@ Imported resources
 
 	it("errors when the descriptor apiVersion is unexpected", func() {
 		testhelpers.CommandTest{
-			K8sObjects: []runtime.Object{kpConfig},
+			Objects: []runtime.Object{kpConfig},
 			Args: []string{
 				"-f", "./testdata/invalid-deps.yaml",
 			},
@@ -900,7 +894,7 @@ status:
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					kpConfig,
 					lifecycleImageConfig,
 				},
@@ -1090,7 +1084,7 @@ status:
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					kpConfig,
 					lifecycleImageConfig,
 				},
@@ -1139,7 +1133,7 @@ Imported resources (dry run)
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					kpConfig,
 					lifecycleImageConfig,
 				},
@@ -1280,7 +1274,7 @@ Importing ClusterBuilder 'default'... (dry run)
 
 			it("does not create a Builder and prints the resource output", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						kpConfig,
 						lifecycleImageConfig,
 					},
@@ -1319,7 +1313,7 @@ Imported resources (dry run with image upload)
 `
 
 			testhelpers.CommandTest{
-				K8sObjects: []runtime.Object{
+				Objects: []runtime.Object{
 					kpConfig,
 					lifecycleImageConfig,
 				},
@@ -1459,7 +1453,7 @@ Importing ClusterBuilder 'default'... (dry run with image upload)
 
 			it("does not create a Builder and prints the resource output", func() {
 				testhelpers.CommandTest{
-					K8sObjects: []runtime.Object{
+					Objects: []runtime.Object{
 						kpConfig,
 						lifecycleImageConfig,
 					},

--- a/pkg/import/importer_test.go
+++ b/pkg/import/importer_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -1402,9 +1401,9 @@ func (i TestImport) TestImporter(t *testing.T) {
 	var err error
 	importer := NewImporter(testLogger{writer: buffer}, k8sClient, client, &fakeFetcher{Images: i.Images}, &fakeRelocator{}, &fakeWaiter{}, &fakeTimestampProvider{ts: time.Time{}.String()})
 	if i.DryRun {
-		_, err = importer.ImportDescriptorDryRun(context.Background(), authn.NewMultiKeychain(), i.KpConfig, strings.NewReader(i.DependencyDescriptor))
+		_, err = importer.ImportDescriptorDryRun(context.Background(), authn.NewMultiKeychain(), i.KpConfig, i.DependencyDescriptor)
 	} else {
-		_, err = importer.ImportDescriptor(context.Background(), authn.NewMultiKeychain(), i.KpConfig, strings.NewReader(i.DependencyDescriptor))
+		_, err = importer.ImportDescriptor(context.Background(), authn.NewMultiKeychain(), i.KpConfig, i.DependencyDescriptor)
 	}
 
 	if i.ExpectErr != nil {

--- a/pkg/registry/uploader_test.go
+++ b/pkg/registry/uploader_test.go
@@ -20,8 +20,8 @@ func TestUploader(t *testing.T) {
 
 func testUploader(t *testing.T, when spec.G, it spec.S) {
 	const (
-		testdataDigest = "sha256:22bd7fd05ebd1bca0d8f8f1e97620ed76b7ff31f41d471b71d023259414c0e15"
-		testZipDigest  = "sha256:5fcd0d53ec99c419061fb4b92d160fa5531791e9a8660447c958879b0777b89a"
+		testdataDigest = "sha256:f261a0e333140b47e51e1cf5a045e704a47842d56ee33962770001582ac6656a"
+		testZipDigest  = "sha256:0a35946b7420d1f6bf0d1397c86cef1f00b08a8575d6045f20914a6845c1376c"
 	)
 
 	when("Upload", func() {

--- a/pkg/testhelpers/command.go
+++ b/pkg/testhelpers/command.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	kpackfakes "github.com/pivotal/kpack/pkg/client/clientset/versioned/fake"
+	kpacktesthelpers "github.com/pivotal/kpack/pkg/reconciler/testhelpers"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,9 +17,7 @@ import (
 )
 
 type CommandTest struct {
-	Objects      []runtime.Object
-	K8sObjects   []runtime.Object
-	KpackObjects []runtime.Object
+	Objects []runtime.Object
 
 	StdIn string
 	Args  []string
@@ -34,8 +33,10 @@ type CommandTest struct {
 
 func (c CommandTest) TestK8sAndKpack(t *testing.T, cmdFactory func(k8sClientSet *k8sfakes.Clientset, kpackClientSet *kpackfakes.Clientset) *cobra.Command) {
 	t.Helper()
-	k8sClient := k8sfakes.NewSimpleClientset(c.K8sObjects...)
-	kpackClient := kpackfakes.NewSimpleClientset(c.KpackObjects...)
+	listers := kpacktesthelpers.NewListers(c.Objects)
+
+	k8sClient := k8sfakes.NewSimpleClientset(listers.GetKubeObjects()...)
+	kpackClient := kpackfakes.NewSimpleClientset(listers.BuildServiceObjects()...)
 
 	cmd := cmdFactory(k8sClient, kpackClient)
 	cmd.SetArgs(c.Args)
@@ -63,53 +64,14 @@ func (c CommandTest) TestK8sAndKpack(t *testing.T, cmdFactory func(k8sClientSet 
 
 func (c CommandTest) TestKpack(t *testing.T, cmdFactory func(clientSet *kpackfakes.Clientset) *cobra.Command) {
 	t.Helper()
-	client := kpackfakes.NewSimpleClientset(c.Objects...)
-
-	cmd := cmdFactory(client)
-	cmd.SetArgs(c.Args)
-
-	out := &bytes.Buffer{}
-	cmd.SetOut(out)
-
-	errOut := &bytes.Buffer{}
-	cmd.SetErr(errOut)
-
-	err := cmd.Execute()
-	if !c.ExpectErr {
-		require.NoError(t, err)
-	} else {
-		require.Error(t, err)
-	}
-
-	require.Equal(t, c.ExpectedOutput, out.String(), "Actual output does not match ExpectedOutput")
-	require.Equal(t, c.ExpectedErrorOutput, errOut.String(), "Actual error output does not match ExpectedErrorOutput")
-	TestKpackActions(t, client, c.ExpectUpdates, c.ExpectCreates, c.ExpectDeletes, c.ExpectPatches)
+	c.TestK8sAndKpack(t, func(k8sClientSet *k8sfakes.Clientset, kpackClientSet *kpackfakes.Clientset) *cobra.Command {
+		return cmdFactory(kpackClientSet)
+	})
 }
 
 func (c CommandTest) TestK8s(t *testing.T, cmdFactory func(clientSet *k8sfakes.Clientset) *cobra.Command) {
 	t.Helper()
-	client := k8sfakes.NewSimpleClientset(c.Objects...)
-
-	cmd := cmdFactory(client)
-	cmd.SetArgs(c.Args)
-
-	inputBuffer := bytes.NewBufferString(c.StdIn)
-	cmd.SetIn(inputBuffer)
-
-	out := &bytes.Buffer{}
-	cmd.SetOut(out)
-
-	errOut := &bytes.Buffer{}
-	cmd.SetErr(errOut)
-
-	err := cmd.Execute()
-	if !c.ExpectErr {
-		require.NoError(t, err)
-	} else {
-		require.Error(t, err)
-	}
-
-	require.Equal(t, c.ExpectedOutput, out.String(), "Actual output does not match ExpectedOutput")
-	require.Equal(t, c.ExpectedErrorOutput, errOut.String(), "Actual error output does not match ExpectedErrorOutput")
-	TestK8sActions(t, client, c.ExpectUpdates, c.ExpectCreates, c.ExpectDeletes, c.ExpectPatches)
+	c.TestK8sAndKpack(t, func(k8sClientSet *k8sfakes.Clientset, kpackClientSet *kpackfakes.Clientset) *cobra.Command {
+		return cmdFactory(k8sClientSet)
+	})
 }

--- a/pkg/testhelpers/command.go
+++ b/pkg/testhelpers/command.go
@@ -40,6 +40,9 @@ func (c CommandTest) TestK8sAndKpack(t *testing.T, cmdFactory func(k8sClientSet 
 	cmd := cmdFactory(k8sClient, kpackClient)
 	cmd.SetArgs(c.Args)
 
+	inputBuffer := bytes.NewBufferString(c.StdIn)
+	cmd.SetIn(inputBuffer)
+
 	out := &bytes.Buffer{}
 	cmd.SetOut(out)
 


### PR DESCRIPTION
Zero out modification time on registry image layers
- This allows the contents of --local-source to be deterministic based on contents
- Allows the uploader test resilient to digest changes