### PR TITLE
Add backwards compatibility for v1alpha1 API

### DIFF
--- a/pkg/commands/build/list.go
+++ b/pkg/commands/build/list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/kpack-cli/pkg/build"
 	"github.com/vmware-tanzu/kpack-cli/pkg/commands"
 	"github.com/vmware-tanzu/kpack-cli/pkg/k8s"
+	"github.com/vmware-tanzu/kpack-cli/pkg/kpack"
 )
 
 func NewListCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
@@ -37,13 +38,17 @@ The namespace defaults to the kubernetes current-context namespace.`,
 				return err
 			}
 
-			opts := metav1.ListOptions{}
+			kpackClient, err := kpack.NewKpackClient(cs.KpackClient)
+			if err != nil {
+				return err
+			}
 
+			opts := metav1.ListOptions{}
 			if len(args) > 0 {
 				opts.LabelSelector = v1alpha2.ImageLabel + "=" + args[0]
 			}
 
-			buildList, err := cs.KpackClient.KpackV1alpha2().Builds(cs.Namespace).List(cmd.Context(), opts)
+			buildList, err := kpackClient.ListBuilds(cmd.Context(), cs.Namespace, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/commands/build/logs.go
+++ b/pkg/commands/build/logs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/kpack-cli/pkg/build"
 	"github.com/vmware-tanzu/kpack-cli/pkg/commands"
 	"github.com/vmware-tanzu/kpack-cli/pkg/k8s"
+	"github.com/vmware-tanzu/kpack-cli/pkg/kpack"
 )
 
 func NewLogsCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
@@ -40,7 +41,12 @@ The namespace defaults to the kubernetes current-context namespace.`,
 				return err
 			}
 
-			buildList, err := cs.KpackClient.KpackV1alpha2().Builds(cs.Namespace).List(cmd.Context(), metav1.ListOptions{
+			kpackClient, err := kpack.NewKpackClient(cs.KpackClient)
+			if err != nil {
+				return err
+			}
+
+			buildList, err := kpackClient.ListBuilds(cmd.Context(), cs.Namespace, metav1.ListOptions{
 				LabelSelector: v1alpha2.ImageLabel + "=" + args[0],
 			})
 			if err != nil {

--- a/pkg/commands/image/list.go
+++ b/pkg/commands/image/list.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vmware-tanzu/kpack-cli/pkg/commands"
 	"github.com/vmware-tanzu/kpack-cli/pkg/k8s"
+	"github.com/vmware-tanzu/kpack-cli/pkg/kpack"
 )
 
 func NewListCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
@@ -39,15 +40,19 @@ kp image list --filter ready=true --filter latest-reason=commit,trigger`,
 				return err
 			}
 
-			var imagesNamespace string
+			kpackClient, err := kpack.NewKpackClient(cs.KpackClient)
+			if err != nil {
+				return err
+			}
 
+			var imagesNamespace string
 			if allNamespaces {
 				imagesNamespace = ""
 			} else {
 				imagesNamespace = cs.Namespace
 			}
 
-			imageList, err := cs.KpackClient.KpackV1alpha2().Images(imagesNamespace).List(cmd.Context(), metav1.ListOptions{})
+			imageList, err := kpackClient.ListImages(cmd.Context(), imagesNamespace, metav1.ListOptions{})
 			if err != nil {
 				return err
 			}

--- a/pkg/kpack/build.go
+++ b/pkg/kpack/build.go
@@ -1,0 +1,56 @@
+package kpack
+
+import (
+	"context"
+
+	buildV1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kpackClient) ListBuilds(ctx context.Context, namespace string, opts v1.ListOptions) (*buildV1alpha2.BuildList, error) {
+	if k.groupVersion == kpackGroupVersionV1alpha2 {
+		return k.client.KpackV1alpha2().Builds(namespace).List(ctx, opts)
+	}
+
+	compatList, err := k.client.KpackV1alpha1().Builds(namespace).List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &buildV1alpha2.BuildList{
+		TypeMeta: compatList.TypeMeta,
+		ListMeta: compatList.ListMeta,
+		Items:    []buildV1alpha2.Build{},
+	}
+
+	for _, compatObj := range compatList.Items {
+		list.Items = append(list.Items, buildV1alpha2.Build{
+			TypeMeta:   compatObj.TypeMeta,
+			ObjectMeta: compatObj.ObjectMeta,
+			Spec: buildV1alpha2.BuildSpec{
+				Tags:                  compatObj.Spec.Tags,
+				Builder:               compatObj.Spec.Builder,
+				ServiceAccount:        compatObj.Spec.ServiceAccount,
+				Source:                compatObj.Spec.Source,
+				Cache:                 nil,
+				Bindings:              compatObj.Spec.Bindings,
+				Env:                   compatObj.Spec.Env,
+				ProjectDescriptorPath: "",
+				Resources:             compatObj.Spec.Resources,
+				LastBuild:             nil,
+				Notary:                compatObj.Spec.Notary,
+			},
+			Status: buildV1alpha2.BuildStatus{
+				Status:           compatObj.Status.Status,
+				BuildMetadata:    compatObj.Status.BuildMetadata,
+				Stack:            compatObj.Status.Stack,
+				LatestImage:      compatObj.Status.LatestImage,
+				LatestCacheImage: "",
+				PodName:          compatObj.Status.PodName,
+				StepStates:       compatObj.Status.StepStates,
+				StepsCompleted:   compatObj.Status.StepsCompleted,
+			},
+		})
+	}
+	return list, nil
+}

--- a/pkg/kpack/client.go
+++ b/pkg/kpack/client.go
@@ -1,0 +1,56 @@
+package kpack
+
+import (
+	"context"
+	"errors"
+
+	"github.com/pivotal/kpack/pkg/apis/build"
+	buildV1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	kpackClientSet "github.com/pivotal/kpack/pkg/client/clientset/versioned"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kpackGroup                = build.GroupName
+	kpackVersionV1alpha2      = "v1alpha2"
+	kpackGroupVersionV1alpha2 = kpackGroup + "/" + kpackVersionV1alpha2
+)
+
+var KpackNotFound = errors.New("kpack not found")
+
+type KpackClient interface {
+	ListBuilds(ctx context.Context, namespace string, opts v1.ListOptions) (*buildV1alpha2.BuildList, error)
+	ListImages(ctx context.Context, namespace string, opts v1.ListOptions) (*buildV1alpha2.ImageList, error)
+}
+
+type kpackClient struct {
+	client kpackClientSet.Interface
+
+	// groupVersion is the prefered kpack api version
+	groupVersion string
+}
+
+func NewKpackClient(client kpackClientSet.Interface) (KpackClient, error) {
+	groups, err := client.Discovery().ServerGroups()
+	if err != nil {
+		return nil, err
+	}
+
+	groupVersion, err := getKpackGroupVersion(groups)
+
+	return &kpackClient{
+		client:       client,
+		groupVersion: groupVersion,
+	}, nil
+}
+
+func getKpackGroupVersion(groups *v1.APIGroupList) (string, error) {
+	var foundGroupVersion = ""
+	for _, g := range groups.Groups {
+		if g.Name == kpackGroup {
+			foundGroupVersion = g.PreferredVersion.GroupVersion
+		}
+	}
+
+	return foundGroupVersion, KpackNotFound
+}

--- a/pkg/kpack/image.go
+++ b/pkg/kpack/image.go
@@ -1,0 +1,57 @@
+package kpack
+
+import (
+	"context"
+
+	buildV1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kpackClient) ListImages(ctx context.Context, namespace string, opts v1.ListOptions) (*buildV1alpha2.ImageList, error) {
+	if k.groupVersion == kpackGroupVersionV1alpha2 {
+		return k.client.KpackV1alpha2().Images(namespace).List(ctx, opts)
+	}
+
+	compatList, err := k.client.KpackV1alpha1().Images(namespace).List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &buildV1alpha2.ImageList{
+		TypeMeta: compatList.TypeMeta,
+		ListMeta: compatList.ListMeta,
+		Items:    []buildV1alpha2.Image{},
+	}
+
+	for _, compatObj := range compatList.Items {
+		list.Items = append(list.Items, buildV1alpha2.Image{
+			TypeMeta:   compatObj.TypeMeta,
+			ObjectMeta: compatObj.ObjectMeta,
+			Spec: buildV1alpha2.ImageSpec{
+				Tag:                      compatObj.Spec.Tag,
+				Builder:                  compatObj.Spec.Builder,
+				ServiceAccount:           compatObj.Spec.ServiceAccount,
+				Source:                   compatObj.Spec.Source,
+				Cache:                    nil,
+				FailedBuildHistoryLimit:  compatObj.Spec.FailedBuildHistoryLimit,
+				SuccessBuildHistoryLimit: compatObj.Spec.SuccessBuildHistoryLimit,
+				ImageTaggingStrategy:     compatObj.Spec.ImageTaggingStrategy,
+				ProjectDescriptorPath:    "",
+				Build:                    compatObj.Spec.Build,
+				Notary:                   compatObj.Spec.Notary,
+			},
+			Status: buildV1alpha2.ImageStatus{
+				Status:                     compatObj.Status.Status,
+				LatestBuildRef:             compatObj.Status.LatestBuildRef,
+				LatestBuildImageGeneration: compatObj.Status.LatestBuildImageGeneration,
+				LatestImage:                compatObj.Status.LatestImage,
+				LatestStack:                compatObj.Status.LatestStack,
+				BuildCounter:               compatObj.Status.BuildCounter,
+				BuildCacheName:             compatObj.Status.BuildCacheName,
+				LatestBuildReason:          compatObj.Status.LatestBuildReason,
+			},
+		})
+	}
+
+	return list, nil
+}


### PR DESCRIPTION
Hi 👋, 

I'd like to get some early feedback on adding backwards compatibility to kp for **v1alpha1** (aka existing kpack version).

Here's a quick analysis I did on the current compatibility: https://docs.google.com/spreadsheets/d/1Zn47YSRLv7KBeHlj_1DwU99-FrWtA-IRCp-AJW9Ievs/edit

### Status

_This PR is currently just a glimps into the direction I'm taking to solve the problem._

* compatibility for `build list`  and `image list` commands

### Implementation Details

My first attempt was to apply a [delegate pattern](https://en.wikipedia.org/wiki/Delegation_pattern) to [latest kpack interface](https://github.com/pivotal/kpack/blob/main/pkg/client/clientset/versioned/typed/build/v1alpha2/build_client.go#L27-L36). Due to the number of nested interfaces (even if unused) it became overly cumbersome.

This latest approach is to use a [facade](https://en.wikipedia.org/wiki/Facade_pattern) that provides automatic compatibility via object transformation based on detected API version. To further simplify the interface, it is structured in a "repository" format for only the methods necessary as oppose to nested resource + operation format.
