### PR TITLE
Add constructors for TLSConfig object

### DIFF
--- a/pkg/import/importer.go
+++ b/pkg/import/importer.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/google/go-containerregistry/pkg/authn"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pivotal/kpack/pkg/apis/build/v1alpha1"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 	"github.com/pivotal/kpack/pkg/client/clientset/versioned"
@@ -22,15 +21,8 @@ import (
 	"github.com/vmware-tanzu/kpack-cli/pkg/commands"
 	"github.com/vmware-tanzu/kpack-cli/pkg/config"
 	"github.com/vmware-tanzu/kpack-cli/pkg/k8s"
+	"github.com/vmware-tanzu/kpack-cli/pkg/registry"
 )
-
-type ImageRelocator interface {
-	Relocate(keychain authn.Keychain, src v1.Image, destination string) (string, error)
-}
-
-type ImageFetcher interface {
-	Fetch(keychain authn.Keychain, image string) (v1.Image, error)
-}
 
 type TimestampProvider interface {
 	GetTimestamp() string
@@ -45,8 +37,8 @@ type Importer struct {
 	client              versioned.Interface
 	k8sClient           kubernetes.Interface
 	printer             Printer
-	imageRelocator      ImageRelocator
-	imageFetcher        ImageFetcher
+	imageRelocator      registry.Relocator
+	imageFetcher        registry.Fetcher
 	waiter              commands.ResourceWaiter
 	clusterStoreFactory *clusterstore.Factory
 	clusterStackFactory *clusterstack.Factory
@@ -60,7 +52,7 @@ type relocatedDescriptor struct {
 	clusterBuilders []*v1alpha1.ClusterBuilder
 }
 
-func NewImporter(printer Printer, k8sClient kubernetes.Interface, client versioned.Interface, fetcher ImageFetcher, relocator ImageRelocator, waiter commands.ResourceWaiter, timestampProvider TimestampProvider) *Importer {
+func NewImporter(printer Printer, k8sClient kubernetes.Interface, client versioned.Interface, fetcher registry.Fetcher, relocator registry.Relocator, waiter commands.ResourceWaiter, timestampProvider TimestampProvider) *Importer {
 	return &Importer{
 		imageRelocator:      relocator,
 		client:              client,

--- a/pkg/registry/fakes/fake_fetcher.go
+++ b/pkg/registry/fakes/fake_fetcher.go
@@ -20,6 +20,7 @@ const (
 type Fetcher struct {
 	images    map[string]v1.Image
 	callCount int
+	err error
 }
 
 type ImageInfo struct {
@@ -63,6 +64,9 @@ func NewLifecycleImageFetcher(i ...LifecycleInfo) *Fetcher {
 
 func (f *Fetcher) Fetch(_ authn.Keychain, src string) (v1.Image, error) {
 	f.callCount++
+	if f.err != nil {
+		return nil, f.err
+	}
 	image, ok := f.images[src]
 	if !ok {
 		return nil, errors.Errorf("image not found: %q", src)
@@ -99,6 +103,10 @@ func (f *Fetcher) AddLifecycleImages(infos ...LifecycleInfo) {
 	for _, i := range infos {
 		images[i.Ref] = NewFakeLabeledImage(lifecycleMetadataLabel, i.Metadata, i.Digest)
 	}
+}
+
+func (f *Fetcher) SetError(err error) {
+	f.err = err
 }
 
 func (f *Fetcher) getImages() map[string]v1.Image {

--- a/pkg/registry/relocator_test.go
+++ b/pkg/registry/relocator_test.go
@@ -79,7 +79,7 @@ func testRelocateStackImages(t *testing.T, when spec.G, it spec.S) {
 			require.NoError(t, err)
 
 			output := &bytes.Buffer{}
-			relocator := registry.NewDefaultRelocator(output, registry.TLSConfig{})
+			relocator := registry.NewDefaultRelocator(output, registry.DefaultTLSConfig())
 			relocatedRef, err := relocator.Relocate(fakeKeychain, srcImage, dst)
 			require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func testRelocateStackImages(t *testing.T, when spec.G, it spec.S) {
 			srcImage, err := random.Image(int64(100), int64(5))
 			require.NoError(t, err)
 
-			relocator := registry.NewDefaultRelocator(ioutil.Discard, registry.TLSConfig{})
+			relocator := registry.NewDefaultRelocator(ioutil.Discard, registry.DefaultTLSConfig())
 			_, err = relocator.Relocate(fakeKeychain, srcImage, "notuser/notimage:tag")
 			require.Error(t, err)
 		})

--- a/pkg/registry/tls_config.go
+++ b/pkg/registry/tls_config.go
@@ -19,6 +19,19 @@ type TLSConfig struct {
 	VerifyCerts bool
 }
 
+func DefaultTLSConfig() TLSConfig {
+	return TLSConfig{
+		VerifyCerts: true,
+	}
+}
+
+func NewTLSConfig(caCertPath string, verifyCerts bool) TLSConfig {
+	return TLSConfig{
+		CaCertPath:  caCertPath,
+		VerifyCerts: verifyCerts,
+	}
+}
+
 func (t *TLSConfig) Transport() (*http.Transport, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {

--- a/pkg/registry/tls_config_test.go
+++ b/pkg/registry/tls_config_test.go
@@ -33,12 +33,9 @@ func testTLSConfig(t *testing.T, when spec.G, it spec.S) {
 		require.NoError(t, err)
 		expectedSubject := cert.RawSubject
 
-		fetcher := registry.TLSConfig{
-			CaCertPath:  certPath,
-			VerifyCerts: false,
-		}
+		cfg := registry.NewTLSConfig(certPath, false)
 
-		transport, err := fetcher.Transport()
+		transport, err := cfg.Transport()
 		require.NoError(t, err)
 		subjects := transport.TLSClientConfig.RootCAs.Subjects()
 
@@ -53,12 +50,9 @@ func testTLSConfig(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("sets skip verify to false when verify certs is true", func() {
-		fetcher := registry.TLSConfig{
-			CaCertPath:  "",
-			VerifyCerts: true,
-		}
+		cfg := registry.NewTLSConfig("", true)
 
-		transport, err := fetcher.Transport()
+		transport, err := cfg.Transport()
 		require.NoError(t, err)
 		require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
 	})


### PR DESCRIPTION
- If TLSConfig is initialized with default values, the transport
  will not have certs verified. This helps mitigate that risk.