### PR TITLE
Add additional tags flag to image write commands

### DIFF
--- a/pkg/commands/image/create.go
+++ b/pkg/commands/image/create.go
@@ -85,7 +85,8 @@ kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-ho
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&tag, "tag", "t", "", "registry location where the image resource will be created")
+	cmd.Flags().StringVarP(&tag, "tag", "t", "", "registry location where the OCI image will be created")
+	cmd.Flags().StringArrayVar(&factory.AdditionalTags, "additional-tag", []string{}, "additional tags to push the OCI image to")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "kubernetes namespace")
 	cmd.Flags().StringVar(&factory.GitRepo, "git", "", "git repository url")
 	cmd.Flags().StringVar(&factory.GitRevision, "git-revision", "", "git revision such as commit, tag, or branch (default \"main\")")

--- a/pkg/commands/image/create_test.go
+++ b/pkg/commands/image/create_test.go
@@ -72,6 +72,10 @@ func testCreateCommand(imageCommand func(clientSetProvider k8s.ClientSetProvider
 					},
 					Spec: v1alpha2.ImageSpec{
 						Tag: "some-registry.io/some-repo",
+						AdditionalTags: []string{
+							"some-registry.io/some-tag",
+							"some-registry.io/some-other-tag",
+						},
 						Builder: corev1.ObjectReference{
 							Kind: v1alpha2.ClusterBuilderKind,
 							Name: "default",
@@ -106,6 +110,8 @@ func testCreateCommand(imageCommand func(clientSetProvider k8s.ClientSetProvider
 						Args: []string{
 							"some-image",
 							"--tag", "some-registry.io/some-repo",
+							"--additional-tag", "some-registry.io/some-tag",
+							"--additional-tag", "some-registry.io/some-other-tag",
 							"--git", "some-git-url",
 							"--git-revision", "some-git-rev",
 							"--sub-path", "some-sub-path",
@@ -136,6 +142,8 @@ Image Resource "some-image" created
 						Args: []string{
 							"some-image",
 							"--tag", "some-registry.io/some-repo",
+							"--additional-tag", "some-registry.io/some-tag",
+							"--additional-tag", "some-registry.io/some-other-tag",
 							"--git", "some-git-url",
 							"--sub-path", "some-sub-path",
 							"--env", "some-key=some-val",

--- a/pkg/commands/image/patch.go
+++ b/pkg/commands/image/patch.go
@@ -100,6 +100,8 @@ kp image patch my-image --env foo=bar --env color=red --delete-env apple --delet
 			return nil
 		},
 	}
+	cmd.Flags().StringArrayVar(&factory.AdditionalTags, "additional-tag", []string{}, "additional tags to push the OCI image to")
+	cmd.Flags().StringArrayVar(&factory.DeleteAdditionalTags, "delete-additional-tag", []string{}, "additional tags to remove")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "kubernetes namespace")
 	cmd.Flags().StringVar(&factory.GitRepo, "git", "", "git repository url")
 	cmd.Flags().StringVar(&factory.GitRevision, "git-revision", "", "git revision such as commit, tag, or branch (default \"main\")")

--- a/pkg/commands/image/save.go
+++ b/pkg/commands/image/save.go
@@ -109,6 +109,8 @@ kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host
 		},
 	}
 	cmd.Flags().StringVarP(&tag, "tag", "t", "", "registry location where the image will be created")
+	cmd.Flags().StringArrayVar(&factory.AdditionalTags, "additional-tag", []string{}, "additional tags to push the OCI image to")
+	cmd.Flags().StringArrayVar(&factory.DeleteAdditionalTags, "delete-additional-tag", []string{}, "additional tags to remove")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "kubernetes namespace")
 	cmd.Flags().StringVar(&factory.GitRepo, "git", "", "git repository url")
 	cmd.Flags().StringVar(&factory.GitRevision, "git-revision", "", "git revision such as commit, tag, or branch (default \"main\")")

--- a/pkg/image/factory_test.go
+++ b/pkg/image/factory_test.go
@@ -113,4 +113,21 @@ func testImageFactory(t *testing.T, when spec.G, it spec.S) {
 			require.EqualError(t, err, "cache size must be greater than 0")
 		})
 	})
+
+	when("additional tags", func() {
+		factory.Blob = "some-blob"
+		it("can be set", func() {
+			additionalTags := []string{"test-registry.io/some-tag", "test-registry.io/some-other-tag"}
+			factory.AdditionalTags = additionalTags
+			img, err := factory.MakeImage("test-name", "test-namespace", "test-registry.io/test-image")
+			require.NoError(t, err)
+			require.Equal(t, img.Spec.AdditionalTags, additionalTags)
+		})
+
+		it("validates additional tags are same registry", func() {
+			factory.AdditionalTags = []string{"test-registry.io/some-tag", "other-test-registry.io/some-other-tag"}
+			_, err := factory.MakeImage("test-name", "test-namespace", "test-registry.io/test-image")
+			require.EqualError(t, err, "all additional tags must have the same registry as tag. expected: test-registry.io, got: other-test-registry.io")
+		})
+	})
 }


### PR DESCRIPTION
- Can be deleted upon patches and saves

This was recreated because I messed up the branches in the original PR: https://github.com/vmware-tanzu/kpack-cli/pull/240

This is identical to the PR that was accepted