### PR TITLE
Made output flag usage more clear with respect to APIVersion

### DIFF
--- a/docs/kp_builder_create.md
+++ b/docs/kp_builder_create.md
@@ -38,6 +38,7 @@ kp builder create my-builder --tag my-registry.com/my-builder-tag --buildpack my
       --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
   -s, --stack string        stack resource to use (default "default")
       --store string        buildpack store to use (default "default")
   -t, --tag string          registry location where the builder will be created

--- a/docs/kp_builder_patch.md
+++ b/docs/kp_builder_patch.md
@@ -37,6 +37,7 @@ kp builder patch my-builder --buildpack my-buildpack-id --buildpack my-other-bui
       --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
   -s, --stack string        stack resource to use
       --store string        buildpack store to use
   -t, --tag string          registry location where the builder will be created

--- a/docs/kp_builder_save.md
+++ b/docs/kp_builder_save.md
@@ -42,6 +42,7 @@ kp builder save my-builder --tag my-registry.com/my-builder-tag --buildpack my-b
       --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
   -s, --stack string        stack resource to use (default "default" for a create)
       --store string        buildpack store to use (default "default" for a create)
   -t, --tag string          registry location where the builder will be created

--- a/docs/kp_clusterbuilder_create.md
+++ b/docs/kp_clusterbuilder_create.md
@@ -40,6 +40,7 @@ kp cb create my-builder --tag my-registry.com/my-builder-tag --buildpack my-buil
       --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
   -s, --stack string        stack resource to use (default "default")
       --store string        buildpack store to use (default "default")
   -t, --tag string          registry location where the builder will be created

--- a/docs/kp_clusterbuilder_patch.md
+++ b/docs/kp_clusterbuilder_patch.md
@@ -34,6 +34,7 @@ kp cb patch my-builder --buildpack my-buildpack-id --buildpack my-other-buildpac
       --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
   -s, --stack string        stack resource to use
       --store string        buildpack store to use
   -t, --tag string          registry location where the builder will be created

--- a/docs/kp_clusterbuilder_save.md
+++ b/docs/kp_clusterbuilder_save.md
@@ -42,6 +42,7 @@ kp cb save my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildp
       --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
   -s, --stack string        stack resource to use (default "default" for a create)
       --store string        buildpack store to use (default "default" for a create)
   -t, --tag string          registry location where the builder will be created

--- a/docs/kp_clusterstack_create.md
+++ b/docs/kp_clusterstack_create.md
@@ -40,6 +40,7 @@ kp clusterstack create my-stack --build-image ../path/to/build.tar --run-image .
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
   -r, --run-image string               run image tag or local tar file path

--- a/docs/kp_clusterstack_patch.md
+++ b/docs/kp_clusterstack_patch.md
@@ -38,6 +38,7 @@ kp clusterstack patch my-stack --build-image ../path/to/build.tar --run-image ..
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
   -r, --run-image string               run image tag or local tar file path

--- a/docs/kp_clusterstack_save.md
+++ b/docs/kp_clusterstack_save.md
@@ -40,6 +40,7 @@ kp clusterstack save my-stack --build-image ../path/to/build.tar --run-image ../
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
   -r, --run-image string               run image tag or local tar file path

--- a/docs/kp_clusterstore_add.md
+++ b/docs/kp_clusterstore_add.md
@@ -39,6 +39,7 @@ kp clusterstore add my-store -b ../path/to/my-local-buildpackage.cnb
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
 ```

--- a/docs/kp_clusterstore_create.md
+++ b/docs/kp_clusterstore_create.md
@@ -41,6 +41,7 @@ kp clusterstore create my-store -b ../path/to/my-local-buildpackage.cnb
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
 ```

--- a/docs/kp_clusterstore_remove.md
+++ b/docs/kp_clusterstore_remove.md
@@ -30,6 +30,7 @@ kp clusterstore remove my-store -b buildpackage@1.0.0 -b other-buildpackage@2.0.
       --output string              print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                      The output can be used with the "kubectl apply -f" command. To allow this, the command
                                      updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                     The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
 ```
 
 ### SEE ALSO

--- a/docs/kp_clusterstore_save.md
+++ b/docs/kp_clusterstore_save.md
@@ -41,6 +41,7 @@ kp clusterstore save my-store -b ../path/to/my-local-buildpackage.cnb
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
 ```

--- a/docs/kp_image_create.md
+++ b/docs/kp_image_create.md
@@ -61,6 +61,7 @@ kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-ho
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
       --sub-path string                build code at the sub path located within the source code directory

--- a/docs/kp_image_patch.md
+++ b/docs/kp_image_patch.md
@@ -69,6 +69,7 @@ kp image patch my-image --env foo=bar --env color=red --delete-env apple --delet
       --output string                       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string        add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs               set whether to verify server's certificate chain and host name (default true)
       --sub-path string                     build code at the sub path located within the source code directory

--- a/docs/kp_image_save.md
+++ b/docs/kp_image_save.md
@@ -65,6 +65,7 @@ kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host
       --output string                       print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                               The output can be used with the "kubectl apply -f" command. To allow this, the command
                                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string        add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs               set whether to verify server's certificate chain and host name (default true)
       --sub-path string                     build code at the sub path located within the source code directory

--- a/docs/kp_import.md
+++ b/docs/kp_import.md
@@ -36,6 +36,7 @@ cat dependencies.yaml | kp import -f -
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
       --show-changes                   show a summary of resource changes before importing

--- a/docs/kp_lifecycle_patch.md
+++ b/docs/kp_lifecycle_patch.md
@@ -37,6 +37,7 @@ kp lifecycle patch --image my-registry.com/lifecycle
       --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                          The output can be used with the "kubectl apply -f" command. To allow this, the command
                                          updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
 ```

--- a/docs/kp_secret_create.md
+++ b/docs/kp_secret_create.md
@@ -57,6 +57,7 @@ kp secret create my-git-cred --git-url https://github.com --git-user my-git-user
       --output string          print Kubernetes resources in the specified format; supported formats are: yaml, json.
                                  The output can be used with the "kubectl apply -f" command. To allow this, the command
                                  updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                 The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
       --registry string        registry
       --registry-user string   registry user
 ```

--- a/pkg/commands/command_flags.go
+++ b/pkg/commands/command_flags.go
@@ -4,29 +4,45 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/kpack-cli/pkg/kpackcompat"
 	"github.com/vmware-tanzu/kpack-cli/pkg/registry"
 )
 
+const (
+	caCertPathFlag  = "registry-ca-cert-path"
+	verifyCertsFlag = "registry-verify-certs"
+
+	caCertPathFlagUsage  = "add CA certificate for registry API (format: /tmp/ca.crt)"
+	verifyCertsFlagUsage = "set whether to verify server's certificate chain and host name"
+	dryRunUsage          = `perform validation with no side-effects; no objects are sent to the server.
+  The --dry-run flag can be used in combination with the --output flag to
+  view the Kubernetes resource(s) without sending anything to the server.`
+	dryRunImgUploadUsage = `similar to --dry-run, but with container image uploads allowed.
+  This flag is provided as a convenience for kp commands that can output Kubernetes
+  resource with generated container image references. A "kubectl apply -f" of the
+  resource from --output without image uploads will result in a reconcile failure.`
+)
+
+var outputUsage = fmt.Sprintf(`print Kubernetes resources in the specified format; supported formats are: yaml, json.
+  The output can be used with the "kubectl apply -f" command. To allow this, the command
+  updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+  The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: %s).`, kpackcompat.LatestKpackAPIVersion)
+
 func SetTLSFlags(cmd *cobra.Command, cfg *registry.TLSConfig) {
-	cmd.Flags().StringVar(&cfg.CaCertPath, "registry-ca-cert-path", "", "add CA certificate for registry API (format: /tmp/ca.crt)")
-	cmd.Flags().BoolVar(&cfg.VerifyCerts, "registry-verify-certs", true, "set whether to verify server's certificate chain and host name")
+	cmd.Flags().StringVar(&cfg.CaCertPath, caCertPathFlag, "", caCertPathFlagUsage)
+	cmd.Flags().BoolVar(&cfg.VerifyCerts, verifyCertsFlag, true, verifyCertsFlagUsage)
 }
 
 func SetDryRunOutputFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(DryRunFlag, false, `perform validation with no side-effects; no objects are sent to the server.
-  The --dry-run flag can be used in combination with the --output flag to
-  view the Kubernetes resource(s) without sending anything to the server.`)
-	cmd.Flags().String(OutputFlag, "", `print Kubernetes resources in the specified format; supported formats are: yaml, json.
-  The output can be used with the "kubectl apply -f" command. To allow this, the command
-  updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.`)
+	cmd.Flags().Bool(DryRunFlag, false, dryRunUsage)
+	cmd.Flags().String(OutputFlag, "", outputUsage)
 }
 
 func SetImgUploadDryRunOutputFlags(cmd *cobra.Command) {
 	SetDryRunOutputFlags(cmd)
-	cmd.Flags().Bool(DryRunImgUploadFlag, false, `similar to --dry-run, but with container image uploads allowed.
-  This flag is provided as a convenience for kp commands that can output Kubernetes
-  resource with generated container image references. A "kubectl apply -f" of the
-  resource from --output without image uploads will result in a reconcile failure.`)
+	cmd.Flags().Bool(DryRunImgUploadFlag, false, dryRunImgUploadUsage)
 }

--- a/pkg/commands/command_helper.go
+++ b/pkg/commands/command_helper.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/vmware-tanzu/kpack-cli/pkg/k8s"
+	"github.com/vmware-tanzu/kpack-cli/pkg/kpackcompat"
 )
 
 type CommandHelper struct {
@@ -223,7 +224,7 @@ func GetStringFlag(name string, cmd *cobra.Command) (string, error) {
 
 func getTypeToGVKLookup() map[reflect.Type]schema.GroupVersionKind {
 	v1GV := schema.GroupVersion{Group: v1.GroupName, Version: "v1"}
-	buildGV := schema.GroupVersion{Group: build.GroupName, Version: "v1alpha2"}
+	buildGV := schema.GroupVersion{Group: build.GroupName, Version: kpackcompat.LatestKpackAPIVersion}
 
 	return map[reflect.Type]schema.GroupVersionKind{
 		reflect.TypeOf(&v1.Secret{}):               v1GV.WithKind("Secret"),

--- a/pkg/kpackcompat/client.go
+++ b/pkg/kpackcompat/client.go
@@ -7,6 +7,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const LatestKpackAPIVersion = "v1alpha2"
+
 type kpackV1alpha1CompatClient struct {
 	v1alpha1KpackClient v1alpha1.KpackV1alpha1Interface
 }


### PR DESCRIPTION
* Added line to help text to make it clear that the output flag only produces resource configs of the most recent APIVersion.
* Introduced APIVersion constant which represents most recent APIVersion.

Signed-off-by: Tyler Phelan <tylerp@vmware.com>