### PR TITLE
Add `--service-binding` flag to image commands

### DIFF
--- a/docs/kp_image_create.md
+++ b/docs/kp_image_create.md
@@ -23,6 +23,10 @@ Environment variables may be provided by using the "--env" flag.
 For each environment variable, supply the "--env" flag followed by the key value pair.
 For example, "--env key1=value1 --env key2=value2 ...".
 
+Service bindings may be provided by using the "--service-binding" flag.
+For each service binding, supply the "--service-binding" flag followed by the <KIND>/<APIVERSION>:<NAME> or just <NAME> which will default the kind to "Secret".
+For example, "--service-binding my-secret-1 --service-binding Secret/v1:my-secret-2 --service-binding CustomProvisionedService/v1beta1:my-ps"
+
 ```
 kp image create <name> --tag <tag> [flags]
 ```
@@ -35,6 +39,7 @@ kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-ho
 kp image create my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code
 kp image create my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code --builder my-builder -n my-namespace
 kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --env foo=bar --env color=red --env food=apple
+kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --service-binding my-secret-1 --service-binding Secret/v1:my-secret-2 --service-binding CustomProvisionedService/v1beta1:my-ps
 ```
 
 ### Options
@@ -65,6 +70,7 @@ kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-ho
       --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
       --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
       --service-account string         service account name to use (default "default")
+  -s, --service-binding stringArray    build time service bindings
       --sub-path string                build code at the sub path located within the source code directory
   -t, --tag string                     registry location where the OCI image will be created
   -w, --wait                           wait for image create to be reconciled and tail resulting build logs

--- a/docs/kp_image_patch.md
+++ b/docs/kp_image_patch.md
@@ -18,13 +18,13 @@ The flags for this command determine how the build will retrieve source code:
 Local source code will be pushed to the same registry as the existing image resource tag.
 Therefore, you must have credentials to access the registry on your machine.
 
-Environment variables may be provided by using the "--env" flag.
+Environment variables may be provided by using the "--env" flag or deleted by using the "--delete-env" flag.
 For each environment variable, supply the "--env" flag followed by the key value pair.
-For example, "--env key1=value1 --env key2=value2 ...".
+For example, "--env key1=value1 --env key2=value2 --delete-env key3 --delete-env key3".
 
-Existing environment variables may be deleted by using the "--delete-env" flag.
-For each environment variable, supply the "--delete-env" flag followed by the variable name.
-For example, "--delete-env key1 --delete-env key2 ...".
+Service bindings may be provided by using the "--service-binding" flag or deleted by using the "--delete-service-binding" flag.
+For each service binding, supply the "--service-binding" flag followed by the <KIND>/<APIVERSION>:<NAME> or just <NAME> which will default the kind to "Secret".
+For example, "--service-binding my-secret-1 --service-binding CustomProvisionedService/v1beta1:my-ps" --delete-service-binding Secret/v1:my-secret-2
 
 The --cache-size flag can only be used to increase the size of the existing cache.
 
@@ -41,40 +41,43 @@ kp image patch my-image --blob https://my-blob-host.com/my-blob
 kp image patch my-image --local-path /path/to/local/source/code
 kp image patch my-image --local-path /path/to/local/source/code --builder my-builder
 kp image patch my-image --env foo=bar --env color=red --delete-env apple --delete-env potato
+kp image patch my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --service-binding my-secret --service-binding CustomProvisionedService/v1:my-ps --delete-service-binding my-secret-2
 ```
 
 ### Options
 
 ```
-      --additional-tag stringArray          additional tags to push the OCI image to
-      --blob string                         source code blob url
-      --builder string                      builder name
-      --cache-size string                   cache size as a kubernetes quantity
-      --cluster-builder string              cluster builder name
-      --delete-additional-tag stringArray   additional tags to remove
-  -d, --delete-env stringArray              build time environment variables to remove
-      --dry-run                             perform validation with no side-effects; no objects are sent to the server.
-                                              The --dry-run flag can be used in combination with the --output flag to
-                                              view the Kubernetes resource(s) without sending anything to the server.
-      --dry-run-with-image-upload           similar to --dry-run, but with container image uploads allowed.
-                                              This flag is provided as a convenience for kp commands that can output Kubernetes
-                                              resource with generated container image references. A "kubectl apply -f" of the
-                                              resource from --output without image uploads will result in a reconcile failure.
-  -e, --env stringArray                     build time environment variables to add/replace
-      --git string                          git repository url
-      --git-revision string                 git revision such as commit, tag, or branch (default "main")
-  -h, --help                                help for patch
-      --local-path string                   path to local source code
-  -n, --namespace string                    kubernetes namespace
-      --output string                       print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                                              The output can be used with the "kubectl apply -f" command. To allow this, the command
-                                              updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-      --registry-ca-cert-path string        add CA certificate for registry API (format: /tmp/ca.crt)
-      --registry-verify-certs               set whether to verify server's certificate chain and host name (default true)
-      --service-account string              service account name to use
-      --sub-path string                     build code at the sub path located within the source code directory
-  -w, --wait                                wait for image resource patch to be reconciled and tail resulting build logs
+      --additional-tag stringArray           additional tags to push the OCI image to
+      --blob string                          source code blob url
+      --builder string                       builder name
+      --cache-size string                    cache size as a kubernetes quantity
+      --cluster-builder string               cluster builder name
+      --delete-additional-tag stringArray    additional tags to remove
+  -d, --delete-env stringArray               build time environment variables to remove
+      --delete-service-binding stringArray   build time service bindings to remove
+      --dry-run                              perform validation with no side-effects; no objects are sent to the server.
+                                               The --dry-run flag can be used in combination with the --output flag to
+                                               view the Kubernetes resource(s) without sending anything to the server.
+      --dry-run-with-image-upload            similar to --dry-run, but with container image uploads allowed.
+                                               This flag is provided as a convenience for kp commands that can output Kubernetes
+                                               resource with generated container image references. A "kubectl apply -f" of the
+                                               resource from --output without image uploads will result in a reconcile failure.
+  -e, --env stringArray                      build time environment variables to add/replace
+      --git string                           git repository url
+      --git-revision string                  git revision such as commit, tag, or branch (default "main")
+  -h, --help                                 help for patch
+      --local-path string                    path to local source code
+  -n, --namespace string                     kubernetes namespace
+      --output string                        print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                               The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                               The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string         add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs                set whether to verify server's certificate chain and host name (default true)
+      --service-account string               service account name to use
+  -s, --service-binding stringArray          build time service bindings to add/replace
+      --sub-path string                      build code at the sub path located within the source code directory
+  -w, --wait                                 wait for image resource patch to be reconciled and tail resulting build logs
 ```
 
 ### SEE ALSO

--- a/docs/kp_image_save.md
+++ b/docs/kp_image_save.md
@@ -21,9 +21,13 @@ The flags for this command determine how the build will retrieve source code:
 Local source code will be pushed to the same registry provided for the image resource tag.
 Therefore, you must have credentials to access the registry on your machine.
 
-Environment variables may be provided by using the "--env" flag.
+Environment variables may be provided by using the "--env" flag or deleted by using the "--delete-env" flag.
 For each environment variable, supply the "--env" flag followed by the key value pair.
-For example, "--env key1=value1 --env key2=value2 ...".
+For example, "--env key1=value1 --env key2=value2 --delete-env key3".
+
+Service bindings may be provided by using the "--service-binding" flag or deleted by using the "--delete-service-binding" flag.
+For each service binding, supply the "--service-binding" flag followed by the <KIND>/<APIVERSION>:<NAME> or just <NAME> which will default the kind to "Secret".
+For example, "--service-binding my-secret-1 --service-binding CustomProvisionedService/v1beta1:my-ps --delete-service-binding Secret/v1:my-secret-2"
 
 ```
 kp image save <name> --tag <tag> [flags]
@@ -36,42 +40,45 @@ kp image create my-image --tag my-registry.com/my-repo --git https://my-repo.com
 kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob
 kp image save my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code
 kp image save my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code --builder my-builder -n my-namespace
-kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --env foo=bar --env color=red --env food=apple
+kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --env foo=bar --env color=red --env food=apple --delete-env apple --delete-env potato
+kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --service-binding my-secret --service-binding CustomProvisionedService/v1:my-ps --delete-service-binding my-secret-2
 ```
 
 ### Options
 
 ```
-      --additional-tag stringArray          additional tags to push the OCI image to
-      --blob string                         source code blob url
-  -b, --builder string                      builder name
-      --cache-size string                   cache size as a kubernetes quantity (default "2G")
-  -c, --cluster-builder string              cluster builder name
-      --delete-additional-tag stringArray   additional tags to remove
-  -d, --delete-env stringArray              build time environment variables to remove
-      --dry-run                             perform validation with no side-effects; no objects are sent to the server.
-                                              The --dry-run flag can be used in combination with the --output flag to
-                                              view the Kubernetes resource(s) without sending anything to the server.
-      --dry-run-with-image-upload           similar to --dry-run, but with container image uploads allowed.
-                                              This flag is provided as a convenience for kp commands that can output Kubernetes
-                                              resource with generated container image references. A "kubectl apply -f" of the
-                                              resource from --output without image uploads will result in a reconcile failure.
-  -e, --env stringArray                     build time environment variables
-      --git string                          git repository url
-      --git-revision string                 git revision such as commit, tag, or branch (default "main")
-  -h, --help                                help for save
-      --local-path string                   path to local source code
-  -n, --namespace string                    kubernetes namespace
-      --output string                       print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                                              The output can be used with the "kubectl apply -f" command. To allow this, the command
-                                              updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-      --registry-ca-cert-path string        add CA certificate for registry API (format: /tmp/ca.crt)
-      --registry-verify-certs               set whether to verify server's certificate chain and host name (default true)
-      --service-account string              service account name to use
-      --sub-path string                     build code at the sub path located within the source code directory
-  -t, --tag string                          registry location where the image will be created
-  -w, --wait                                wait for image create to be reconciled and tail resulting build logs
+      --additional-tag stringArray           additional tags to push the OCI image to
+      --blob string                          source code blob url
+  -b, --builder string                       builder name
+      --cache-size string                    cache size as a kubernetes quantity (default "2G")
+  -c, --cluster-builder string               cluster builder name
+      --delete-additional-tag stringArray    additional tags to remove
+  -d, --delete-env stringArray               build time environment variables to remove
+      --delete-service-binding stringArray   build time service bindings to remove
+      --dry-run                              perform validation with no side-effects; no objects are sent to the server.
+                                               The --dry-run flag can be used in combination with the --output flag to
+                                               view the Kubernetes resource(s) without sending anything to the server.
+      --dry-run-with-image-upload            similar to --dry-run, but with container image uploads allowed.
+                                               This flag is provided as a convenience for kp commands that can output Kubernetes
+                                               resource with generated container image references. A "kubectl apply -f" of the
+                                               resource from --output without image uploads will result in a reconcile failure.
+  -e, --env stringArray                      build time environment variables
+      --git string                           git repository url
+      --git-revision string                  git revision such as commit, tag, or branch (default "main")
+  -h, --help                                 help for save
+      --local-path string                    path to local source code
+  -n, --namespace string                     kubernetes namespace
+      --output string                        print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                               The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                               updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                               The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string         add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs                set whether to verify server's certificate chain and host name (default true)
+      --service-account string               service account name to use
+  -s, --service-binding stringArray          build time service bindings to add/replace
+      --sub-path string                      build code at the sub path located within the source code directory
+  -t, --tag string                           registry location where the image will be created
+  -w, --wait                                 wait for image create to be reconciled and tail resulting build logs
 ```
 
 ### SEE ALSO

--- a/pkg/commands/image/create.go
+++ b/pkg/commands/image/create.go
@@ -45,12 +45,17 @@ Therefore, you must have credentials to access the registry on your machine.
 
 Environment variables may be provided by using the "--env" flag.
 For each environment variable, supply the "--env" flag followed by the key value pair.
-For example, "--env key1=value1 --env key2=value2 ...".`,
+For example, "--env key1=value1 --env key2=value2 ...".
+
+Service bindings may be provided by using the "--service-binding" flag.
+For each service binding, supply the "--service-binding" flag followed by the <KIND>:<APIVERSION>:<NAME> or just <NAME> which will default the kind to "Secret".
+For example, "--service-binding my-secret-1 --service-binding Secret:v1:my-secret-2 --service-binding CustomProvisionedService:v1beta1:my-ps"`,
 		Example: `kp image create my-image --tag my-registry.com/my-repo --git https://my-repo.com/my-app.git --git-revision my-branch
 kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob
 kp image create my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code
 kp image create my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code --builder my-builder -n my-namespace
-kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --env foo=bar --env color=red --env food=apple`,
+kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --env foo=bar --env color=red --env food=apple
+kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --service-binding my-secret-1 --service-binding Secret:v1:my-secret-2 --service-binding CustomProvisionedService:v1beta1:my-ps`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -96,6 +101,7 @@ kp image create my-image --tag my-registry.com/my-repo --blob https://my-blob-ho
 	cmd.Flags().StringVarP(&factory.Builder, "builder", "b", "", "builder name")
 	cmd.Flags().StringVarP(&factory.ClusterBuilder, "cluster-builder", "c", "", "cluster builder name")
 	cmd.Flags().StringArrayVarP(&factory.Env, "env", "e", []string{}, "build time environment variables")
+	cmd.Flags().StringArrayVarP(&factory.ServiceBinding, "service-binding", "s", []string{}, "build time service bindings")
 	cmd.Flags().StringVar(&factory.CacheSize, "cache-size", "", "cache size as a kubernetes quantity (default \"2G\")")
 	cmd.Flags().StringVar(&factory.ServiceAccount, "service-account", "default", "service account name to use")
 	cmd.Flags().BoolP("wait", "w", false, "wait for image create to be reconciled and tail resulting build logs")

--- a/pkg/commands/image/patch.go
+++ b/pkg/commands/image/patch.go
@@ -43,13 +43,13 @@ The flags for this command determine how the build will retrieve source code:
 Local source code will be pushed to the same registry as the existing image resource tag.
 Therefore, you must have credentials to access the registry on your machine.
 
-Environment variables may be provided by using the "--env" flag.
+Environment variables may be provided by using the "--env" flag or deleted by using the "--delete-env" flag.
 For each environment variable, supply the "--env" flag followed by the key value pair.
-For example, "--env key1=value1 --env key2=value2 ...".
+For example, "--env key1=value1 --env key2=value2 --delete-env key3 --delete-env key3".
 
-Existing environment variables may be deleted by using the "--delete-env" flag.
-For each environment variable, supply the "--delete-env" flag followed by the variable name.
-For example, "--delete-env key1 --delete-env key2 ...".
+Service bindings may be provided by using the "--service-binding" flag or deleted by using the "--delete-service-binding" flag.
+For each service binding, supply the "--service-binding" flag followed by the <KIND>:<APIVERSION>:<NAME> or just <NAME> which will default the kind to "Secret".
+For example, "--service-binding my-secret-1 --service-binding CustomProvisionedService:v1beta1:my-ps" --delete-service-binding Secret:v1:my-secret-2
 
 The --cache-size flag can only be used to increase the size of the existing cache.
 `,
@@ -57,7 +57,8 @@ The --cache-size flag can only be used to increase the size of the existing cach
 kp image patch my-image --blob https://my-blob-host.com/my-blob
 kp image patch my-image --local-path /path/to/local/source/code
 kp image patch my-image --local-path /path/to/local/source/code --builder my-builder
-kp image patch my-image --env foo=bar --env color=red --delete-env apple --delete-env potato`,
+kp image patch my-image --env foo=bar --env color=red --delete-env apple --delete-env potato
+kp image patch my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --service-binding my-secret --service-binding CustomProvisionedService:v1:my-ps --delete-service-binding Secret:v1:my-secret-2`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -112,6 +113,8 @@ kp image patch my-image --env foo=bar --env color=red --delete-env apple --delet
 	cmd.Flags().StringVar(&factory.ClusterBuilder, "cluster-builder", "", "cluster builder name")
 	cmd.Flags().StringArrayVarP(&factory.Env, "env", "e", []string{}, "build time environment variables to add/replace")
 	cmd.Flags().StringArrayVarP(&factory.DeleteEnv, "delete-env", "d", []string{}, "build time environment variables to remove")
+	cmd.Flags().StringArrayVarP(&factory.ServiceBinding, "service-binding", "s", []string{}, "build time service bindings to add/replace")
+	cmd.Flags().StringArrayVarP(&factory.DeleteServiceBinding, "delete-service-binding", "", []string{}, "build time service bindings to remove")
 	cmd.Flags().StringVar(&factory.CacheSize, "cache-size", "", "cache size as a kubernetes quantity")
 	cmd.Flags().StringVar(&factory.ServiceAccount, "service-account", "", "service account name to use")
 	cmd.Flags().BoolP("wait", "w", false, "wait for image resource patch to be reconciled and tail resulting build logs")

--- a/pkg/commands/image/save.go
+++ b/pkg/commands/image/save.go
@@ -45,14 +45,20 @@ The flags for this command determine how the build will retrieve source code:
 Local source code will be pushed to the same registry provided for the image resource tag.
 Therefore, you must have credentials to access the registry on your machine.
 
-Environment variables may be provided by using the "--env" flag.
+Environment variables may be provided by using the "--env" flag or deleted by using the "--delete-env" flag.
 For each environment variable, supply the "--env" flag followed by the key value pair.
-For example, "--env key1=value1 --env key2=value2 ...".`,
+For example, "--env key1=value1 --env key2=value2 --delete-env key3".
+
+Service bindings may be provided by using the "--service-binding" flag or deleted by using the "--delete-service-binding" flag.
+For each service binding, supply the "--service-binding" flag followed by the <KIND>:<APIVERSION>:<NAME> or just <NAME> which will default the kind to "Secret".
+For example, "--service-binding my-secret-1 --service-binding CustomProvisionedService:v1beta1:my-ps --delete-service-binding Secret:v1:my-secret-2"
+`,
 		Example: `kp image create my-image --tag my-registry.com/my-repo --git https://my-repo.com/my-app.git --git-revision my-branch
 kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob
 kp image save my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code
 kp image save my-image --tag my-registry.com/my-repo --local-path /path/to/local/source/code --builder my-builder -n my-namespace
-kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --env foo=bar --env color=red --env food=apple`,
+kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --env foo=bar --env color=red --env food=apple --delete-env apple --delete-env potato
+kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host.com/my-blob --service-binding my-secret --service-binding CustomProvisionedService:v1:my-ps --delete-service-binding Secret:v1:my-secret-2`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -122,6 +128,8 @@ kp image save my-image --tag my-registry.com/my-repo --blob https://my-blob-host
 	cmd.Flags().StringVarP(&factory.ClusterBuilder, "cluster-builder", "c", "", "cluster builder name")
 	cmd.Flags().StringArrayVarP(&factory.Env, "env", "e", []string{}, "build time environment variables")
 	cmd.Flags().StringArrayVarP(&factory.DeleteEnv, "delete-env", "d", []string{}, "build time environment variables to remove")
+	cmd.Flags().StringArrayVarP(&factory.ServiceBinding, "service-binding", "s", []string{}, "build time service bindings to add/replace")
+	cmd.Flags().StringArrayVarP(&factory.DeleteServiceBinding, "delete-service-binding", "", []string{}, "build time service bindings to remove")
 	cmd.Flags().StringVar(&factory.ServiceAccount, "service-account", "", "service account name to use")
 	cmd.Flags().BoolP("wait", "w", false, "wait for image create to be reconciled and tail resulting build logs")
 	commands.SetImgUploadDryRunOutputFlags(cmd)

--- a/pkg/image/update_factory.go
+++ b/pkg/image/update_factory.go
@@ -282,6 +282,27 @@ func (f *Factory) setBuild(image *v1alpha2.Image) error {
 		}
 	}
 
+	svcsToDelete, err := parseServiceBindings(f.DeleteServiceBinding)
+	if err != nil {
+		return err
+	}
+
+	for _, svc := range svcsToDelete {
+		for i, e := range image.Spec.Build.Services {
+			if e.Kind == svc.Kind && e.APIVersion == svc.APIVersion && e.Name == svc.Name {
+				image.Spec.Build.Services = append(image.Spec.Build.Services[:i], image.Spec.Build.Services[i+1:]...)
+				break
+			}
+		}
+	}
+
+	svcsToSave, err := parseServiceBindings(f.ServiceBinding)
+	if err != nil {
+		return err
+	}
+
+	image.Spec.Build.Services = append(image.Spec.Build.Services, svcsToSave...)
+
 	return nil
 }
 


### PR DESCRIPTION
fixes #235 

Add `--service-binding <KIND>:<API VERSION>:<NAME>` to `kp image create/patch/save` (and `--delete-service-binding` to `patch/save`)