### PR TITLE
Check for existing service-binding before adding

### DIFF
--- a/pkg/image/update_factory.go
+++ b/pkg/image/update_factory.go
@@ -300,8 +300,20 @@ func (f *Factory) setBuild(image *v1alpha2.Image) error {
 	if err != nil {
 		return err
 	}
+	for _, svc := range svcsToSave {
+		exists := false
 
-	image.Spec.Build.Services = append(image.Spec.Build.Services, svcsToSave...)
+		for _, e := range image.Spec.Build.Services {
+			if e.Name == svc.Name && e.Kind == svc.Kind && e.APIVersion == svc.APIVersion {
+				exists = true
+				break
+			}
+		}
+
+		if !exists {
+			image.Spec.Build.Services = append(image.Spec.Build.Services, svcsToSave...)
+		}
+	}
 
 	return nil
 }

--- a/pkg/image/update_factory_test.go
+++ b/pkg/image/update_factory_test.go
@@ -54,6 +54,13 @@ func testPatchFactory(t *testing.T, when spec.G, it spec.S) {
 							Value: "",
 						},
 					},
+					Services: v1alpha2.Services{
+						{
+							Name:       "svc-binding",
+							APIVersion: "v1",
+							Kind:       "Secret",
+						},
+					},
 				},
 				AdditionalTags: []string{"some-other-tag"},
 			},
@@ -188,6 +195,16 @@ func testPatchFactory(t *testing.T, when spec.G, it spec.S) {
 				Name:  "BP_MAVEN_BUILD_ARGUMENTS",
 				Value: `"-Dmaven.test.skip=true -Pk8s package"`,
 			})
+
+			updatedImg, err := factory.UpdateImage(img)
+			require.NoError(t, err)
+			require.Equal(t, expectedImg, updatedImg)
+		})
+	})
+
+	when("a services var has the same value as the existing Image", func() {
+		it("handles the services var", func() {
+			factory.ServiceBinding = append(factory.ServiceBinding, "Secret:v1:svc-binding")
 
 			updatedImg, err := factory.UpdateImage(img)
 			require.NoError(t, err)


### PR DESCRIPTION
This fixes a bug where you can't use `kp image save` with a --service-binding if the Image Resource already included this service-binding. This was being handled for the --env option.