### PR TITLE
ci: Fix release step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,6 +93,8 @@ jobs:
       - build
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -125,7 +127,6 @@ jobs:
         name: kp v${{ env.VERSION }}
         tag_name: v${{ env.VERSION }}
         target_commitish: ${{ github.sha }}
-        token: ${{ secrets.RELEASE_TOKEN }}
         draft: true
         prerelease: true
         generate_release_notes: true


### PR DESCRIPTION
Provide required permissions and remove obsolete 'token' field.