### PR TITLE
feat: add support for order from : #384

### DIFF
--- a/docs/kp_builder_create.md
+++ b/docs/kp_builder_create.md
@@ -7,8 +7,8 @@ Create a builder
 Create a builder by providing command line arguments.
 The builder will be created only if it does not exist in the provided namespace.
 
-A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
-Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+A buildpack order must be provided with either the path to an order yaml, via the --buildpack flag, or extracted from a builder image using --order-from.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group.
 
 The namespace defaults to the kubernetes current-context namespace.
 
@@ -21,28 +21,32 @@ kp builder create <name> --tag <tag> [flags]
 ```
 kp builder create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml --stack tiny --store my-store
 kp builder create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml
+kp builder create my-builder --tag my-registry.com/my-builder-tag --order-from paketobuildpacks/builder-jammy-base --stack tiny --store my-store
 kp builder create my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1
 ```
 
 ### Options
 
 ```
-  -b, --buildpack strings        buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
-                                   repeat for each buildpack in order, or supply once with comma-separated list
-      --dry-run                  perform validation with no side-effects; no objects are sent to the server.
-                                   The --dry-run flag can be used in combination with the --output flag to
-                                   view the Kubernetes resource(s) without sending anything to the server.
-  -h, --help                     help for create
-  -n, --namespace string         kubernetes namespace
-  -o, --order string             path to buildpack order yaml
-      --output string            print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                                   The output can be used with the "kubectl apply -f" command. To allow this, the command
-                                   updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                                   The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-      --service-account string   service account name to use (default "default")
-  -s, --stack string             stack resource to use (default "default")
-      --store string             buildpack store to use
-  -t, --tag string               registry location where the builder will be created
+  -b, --buildpack strings              buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
+                                         repeat for each buildpack in order, or supply once with comma-separated list
+      --dry-run                        perform validation with no side-effects; no objects are sent to the server.
+                                         The --dry-run flag can be used in combination with the --output flag to
+                                         view the Kubernetes resource(s) without sending anything to the server.
+  -h, --help                           help for create
+  -n, --namespace string               kubernetes namespace
+  -o, --order string                   path to buildpack order yaml
+      --order-from string              builder image to extract buildpack order from
+      --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                         The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                         updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
+      --service-account string         service account name to use (default "default")
+  -s, --stack string                   stack resource to use (default "default")
+      --store string                   buildpack store to use
+  -t, --tag string                     registry location where the builder will be created
 ```
 
 ### SEE ALSO

--- a/docs/kp_builder_patch.md
+++ b/docs/kp_builder_patch.md
@@ -26,22 +26,25 @@ kp builder patch my-builder --buildpack my-buildpack-id --buildpack my-other-bui
 ### Options
 
 ```
-  -b, --buildpack strings        buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
-                                   repeat for each buildpack in order, or supply once with comma-separated list
-      --dry-run                  perform validation with no side-effects; no objects are sent to the server.
-                                   The --dry-run flag can be used in combination with the --output flag to
-                                   view the Kubernetes resource(s) without sending anything to the server.
-  -h, --help                     help for patch
-  -n, --namespace string         kubernetes namespace
-  -o, --order string             path to buildpack order yaml
-      --output string            print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                                   The output can be used with the "kubectl apply -f" command. To allow this, the command
-                                   updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                                   The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-      --service-account string   service account name to use
-  -s, --stack string             stack resource to use
-      --store string             buildpack store to use
-  -t, --tag string               registry location where the builder will be created
+  -b, --buildpack strings              buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
+                                         repeat for each buildpack in order, or supply once with comma-separated list
+      --dry-run                        perform validation with no side-effects; no objects are sent to the server.
+                                         The --dry-run flag can be used in combination with the --output flag to
+                                         view the Kubernetes resource(s) without sending anything to the server.
+  -h, --help                           help for patch
+  -n, --namespace string               kubernetes namespace
+  -o, --order string                   path to buildpack order yaml
+      --order-from string              builder image to extract buildpack order from
+      --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                         The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                         updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
+      --service-account string         service account name to use
+  -s, --stack string                   stack resource to use
+      --store string                   buildpack store to use
+  -t, --tag string                     registry location where the builder will be created
 ```
 
 ### SEE ALSO

--- a/docs/kp_builder_save.md
+++ b/docs/kp_builder_save.md
@@ -31,22 +31,25 @@ kp builder save my-builder --tag my-registry.com/my-builder-tag --buildpack my-b
 ### Options
 
 ```
-  -b, --buildpack strings        buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
-                                   repeat for each buildpack in order, or supply once with comma-separated list
-      --dry-run                  perform validation with no side-effects; no objects are sent to the server.
-                                   The --dry-run flag can be used in combination with the --output flag to
-                                   view the Kubernetes resource(s) without sending anything to the server.
-  -h, --help                     help for save
-  -n, --namespace string         kubernetes namespace
-  -o, --order string             path to buildpack order yaml
-      --output string            print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                                   The output can be used with the "kubectl apply -f" command. To allow this, the command
-                                   updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                                   The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-      --service-account string   service account name to use
-  -s, --stack string             stack resource to use (default "default" for a create)
-      --store string             buildpack store to use
-  -t, --tag string               registry location where the builder will be created
+  -b, --buildpack strings              buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
+                                         repeat for each buildpack in order, or supply once with comma-separated list
+      --dry-run                        perform validation with no side-effects; no objects are sent to the server.
+                                         The --dry-run flag can be used in combination with the --output flag to
+                                         view the Kubernetes resource(s) without sending anything to the server.
+  -h, --help                           help for save
+  -n, --namespace string               kubernetes namespace
+  -o, --order string                   path to buildpack order yaml
+      --order-from string              builder image to extract buildpack order from
+      --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                         The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                         updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
+      --service-account string         service account name to use
+  -s, --stack string                   stack resource to use (default "default" for a create)
+      --store string                   buildpack store to use
+  -t, --tag string                     registry location where the builder will be created
 ```
 
 ### SEE ALSO

--- a/docs/kp_clusterbuilder_create.md
+++ b/docs/kp_clusterbuilder_create.md
@@ -7,8 +7,8 @@ Create a cluster builder
 Create a cluster builder by providing command line arguments.
 The cluster builder will be created only if it does not exist.
 
-A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
-Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+A buildpack order must be provided with either the path to an order yaml, via the --buildpack flag, or extracted from a builder image using --order-from.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group.
 
 Tag when not specified, defaults to a combination of the default repository and specified builder name.
 The default repository is read from the "default.repository" key in the "kp-config" ConfigMap within "kpack" namespace.
@@ -23,6 +23,7 @@ kp clusterbuilder create <name> [flags]
 ```
 kp clusterbuilder create my-builder --order /path/to/order.yaml --stack tiny --store my-store
 kp clusterbuilder create my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1
+kp clusterbuilder create my-builder --order-from paketobuildpacks/builder-jammy-base --stack tiny --store my-store
 kp clusterbuilder create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml --stack tiny --store my-store
 kp clusterbuilder create my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1
 ```
@@ -30,20 +31,23 @@ kp clusterbuilder create my-builder --tag my-registry.com/my-builder-tag --build
 ### Options
 
 ```
-  -b, --buildpack strings   buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
-                              repeat for each buildpack in order, or supply once with comma-separated list
-      --dry-run             perform validation with no side-effects; no objects are sent to the server.
-                              The --dry-run flag can be used in combination with the --output flag to
-                              view the Kubernetes resource(s) without sending anything to the server.
-  -h, --help                help for create
-  -o, --order string        path to buildpack order yaml
-      --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                              The output can be used with the "kubectl apply -f" command. To allow this, the command
-                              updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-  -s, --stack string        stack resource to use (default "default")
-      --store string        buildpack store to use
-  -t, --tag string          registry location where the builder will be created
+  -b, --buildpack strings              buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
+                                         repeat for each buildpack in order, or supply once with comma-separated list
+      --dry-run                        perform validation with no side-effects; no objects are sent to the server.
+                                         The --dry-run flag can be used in combination with the --output flag to
+                                         view the Kubernetes resource(s) without sending anything to the server.
+  -h, --help                           help for create
+  -o, --order string                   path to buildpack order yaml
+      --order-from string              builder image to extract buildpack order from
+      --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                         The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                         updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
+  -s, --stack string                   stack resource to use (default "default")
+      --store string                   buildpack store to use
+  -t, --tag string                     registry location where the builder will be created
 ```
 
 ### SEE ALSO

--- a/docs/kp_clusterbuilder_patch.md
+++ b/docs/kp_clusterbuilder_patch.md
@@ -6,7 +6,7 @@ Patch an existing cluster builder configuration
 
 Patch an existing clusterbuilder configuration by providing command line arguments.
 
-A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+A buildpack order must be provided with either the path to an order yaml, via the --buildpack flag, or extracted from a builder image using --order-from.
 Multiple buildpacks provided via the --buildpack flag will be added to the same order group.
 
 ```
@@ -18,26 +18,30 @@ kp clusterbuilder patch <name> [flags]
 ```
 kp clusterbuilder patch my-builder --order /path/to/order.yaml --stack tiny --store my-store
 kp clusterbuilder patch my-builder --order /path/to/order.yaml
+kp clusterbuilder patch my-builder --order-from paketobuildpacks/builder-jammy-base
 kp clusterbuilder patch my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1
 ```
 
 ### Options
 
 ```
-  -b, --buildpack strings   buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
-                              repeat for each buildpack in order, or supply once with comma-separated list
-      --dry-run             perform validation with no side-effects; no objects are sent to the server.
-                              The --dry-run flag can be used in combination with the --output flag to
-                              view the Kubernetes resource(s) without sending anything to the server.
-  -h, --help                help for patch
-  -o, --order string        path to buildpack order yaml
-      --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                              The output can be used with the "kubectl apply -f" command. To allow this, the command
-                              updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-  -s, --stack string        stack resource to use
-      --store string        buildpack store to use
-  -t, --tag string          registry location where the builder will be created
+  -b, --buildpack strings              buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
+                                         repeat for each buildpack in order, or supply once with comma-separated list
+      --dry-run                        perform validation with no side-effects; no objects are sent to the server.
+                                         The --dry-run flag can be used in combination with the --output flag to
+                                         view the Kubernetes resource(s) without sending anything to the server.
+  -h, --help                           help for patch
+  -o, --order string                   path to buildpack order yaml
+      --order-from string              builder image to extract buildpack order from
+      --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                         The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                         updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
+  -s, --stack string                   stack resource to use
+      --store string                   buildpack store to use
+  -t, --tag string                     registry location where the builder will be created
 ```
 
 ### SEE ALSO

--- a/docs/kp_clusterbuilder_save.md
+++ b/docs/kp_clusterbuilder_save.md
@@ -32,20 +32,23 @@ kp clusterbuilder save my-builder --tag my-registry.com/my-builder-tag --buildpa
 ### Options
 
 ```
-  -b, --buildpack strings   buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
-                              repeat for each buildpack in order, or supply once with comma-separated list
-      --dry-run             perform validation with no side-effects; no objects are sent to the server.
-                              The --dry-run flag can be used in combination with the --output flag to
-                              view the Kubernetes resource(s) without sending anything to the server.
-  -h, --help                help for save
-  -o, --order string        path to buildpack order yaml
-      --output string       print Kubernetes resources in the specified format; supported formats are: yaml, json.
-                              The output can be used with the "kubectl apply -f" command. To allow this, the command
-                              updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
-                              The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
-  -s, --stack string        stack resource to use (default "default" for a create)
-      --store string        buildpack store to use
-  -t, --tag string          registry location where the builder will be created
+  -b, --buildpack strings              buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'
+                                         repeat for each buildpack in order, or supply once with comma-separated list
+      --dry-run                        perform validation with no side-effects; no objects are sent to the server.
+                                         The --dry-run flag can be used in combination with the --output flag to
+                                         view the Kubernetes resource(s) without sending anything to the server.
+  -h, --help                           help for save
+  -o, --order string                   path to buildpack order yaml
+      --order-from string              builder image to extract buildpack order from
+      --output string                  print Kubernetes resources in the specified format; supported formats are: yaml, json.
+                                         The output can be used with the "kubectl apply -f" command. To allow this, the command
+                                         updates are redirected to stderr and only the Kubernetes resource(s) are written to stdout.
+                                         The APIVersion of the outputted resources will always be the latest APIVersion known to kp (currently: v1alpha2).
+      --registry-ca-cert-path string   add CA certificate for registry API (format: /tmp/ca.crt)
+      --registry-verify-certs          set whether to verify server's certificate chain and host name (default true)
+  -s, --stack string                   stack resource to use (default "default" for a create)
+      --store string                   buildpack store to use
+  -t, --tag string                     registry location where the builder will be created
 ```
 
 ### SEE ALSO

--- a/pkg/builder/helpers.go
+++ b/pkg/builder/helpers.go
@@ -4,15 +4,39 @@
 package builder
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"regexp"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/pkg/errors"
 	buildv1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
 	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
 )
+
+const (
+	builderOrderLabel = "io.buildpacks.buildpack.order"
+)
+
+type Fetcher interface {
+	Fetch(keychain authn.Keychain, src string) (v1.Image, error)
+}
+
+// cnbOrderEntry represents the structure of a buildpack order entry in the CNB builder image label
+type cnbOrderEntry struct {
+	Group []cnbBuildpackRef `json:"group"`
+}
+
+// cnbBuildpackRef represents a buildpack reference in the CNB builder image label
+type cnbBuildpackRef struct {
+	ID       string `json:"id"`
+	Version  string `json:"version,omitempty"`
+	Optional bool   `json:"optional,omitempty"`
+}
 
 func ReadOrder(path string) ([]buildv1alpha2.BuilderOrderEntry, error) {
 	var (
@@ -94,4 +118,49 @@ func CoreOrderEntryToBuildOrderEntry(order []corev1alpha1.OrderEntry) []buildv1a
 		}
 	}
 	return res
+}
+
+// ReadOrderFromImage extracts the buildpack order from a CNB builder image's io.buildpacks.buildpack.order label
+func ReadOrderFromImage(keychain authn.Keychain, fetcher Fetcher, imageRef string) ([]buildv1alpha2.BuilderOrderEntry, error) {
+	img, err := fetcher.Fetch(keychain, imageRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch image %s", imageRef)
+	}
+
+	config, err := img.ConfigFile()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read image config")
+	}
+
+	orderJSON, ok := config.Config.Labels[builderOrderLabel]
+	if !ok {
+		return nil, errors.Errorf("image %s does not contain the %s label", imageRef, builderOrderLabel)
+	}
+
+	var cnbOrder []cnbOrderEntry
+	if err := json.Unmarshal([]byte(orderJSON), &cnbOrder); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse %s label", builderOrderLabel)
+	}
+
+	// Convert CNB order format to kpack BuilderOrderEntry format
+	order := make([]buildv1alpha2.BuilderOrderEntry, len(cnbOrder))
+	for i, entry := range cnbOrder {
+		group := make([]buildv1alpha2.BuilderBuildpackRef, len(entry.Group))
+		for j, ref := range entry.Group {
+			group[j] = buildv1alpha2.BuilderBuildpackRef{
+				BuildpackRef: corev1alpha1.BuildpackRef{
+					BuildpackInfo: corev1alpha1.BuildpackInfo{
+						Id:      ref.ID,
+						Version: ref.Version,
+					},
+					Optional: ref.Optional,
+				},
+			}
+		}
+		order[i] = buildv1alpha2.BuilderOrderEntry{
+			Group: group,
+		}
+	}
+
+	return order, nil
 }

--- a/pkg/builder/helpers_test.go
+++ b/pkg/builder/helpers_test.go
@@ -1,0 +1,164 @@
+// Copyright 2020-Present VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package builder_test
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/fake"
+	buildv1alpha2 "github.com/pivotal/kpack/pkg/apis/build/v1alpha2"
+	corev1alpha1 "github.com/pivotal/kpack/pkg/apis/core/v1alpha1"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/buildpacks-community/kpack-cli/pkg/builder"
+	"github.com/buildpacks-community/kpack-cli/pkg/testhelpers"
+)
+
+func TestReadOrderFromImage(t *testing.T) {
+	spec.Run(t, "TestReadOrderFromImage", testReadOrderFromImage)
+}
+
+func testReadOrderFromImage(t *testing.T, when spec.G, it spec.S) {
+	var (
+		fakeFetcher *testhelpers.FakeFetcher
+		keychain    authn.Keychain
+		imageRef    = "some-registry.io/builder:tag"
+	)
+
+	it.Before(func() {
+		fakeFetcher = &testhelpers.FakeFetcher{}
+		keychain = authn.DefaultKeychain
+	})
+
+	when("the image contains a valid order label", func() {
+		it("extracts the order successfully", func() {
+			orderJSON := `[
+				{
+					"group": [
+						{
+							"id": "org.cloudfoundry.nodejs",
+							"version": "1.2.3"
+						},
+						{
+							"id": "org.cloudfoundry.npm",
+							"version": "4.5.6",
+							"optional": true
+						}
+					]
+				},
+				{
+					"group": [
+						{
+							"id": "org.cloudfoundry.go"
+						}
+					]
+				}
+			]`
+
+			fakeImage := &fake.FakeImage{}
+			fakeImage.ConfigFileReturns(&v1.ConfigFile{
+				Config: v1.Config{
+					Labels: map[string]string{
+						"io.buildpacks.buildpack.order": orderJSON,
+					},
+				},
+			}, nil)
+
+			fakeFetcher.SetImage(imageRef, fakeImage)
+
+			order, err := builder.ReadOrderFromImage(keychain, fakeFetcher, imageRef)
+			require.NoError(t, err)
+
+			expectedOrder := []buildv1alpha2.BuilderOrderEntry{
+				{
+					Group: []buildv1alpha2.BuilderBuildpackRef{
+						{
+							BuildpackRef: corev1alpha1.BuildpackRef{
+								BuildpackInfo: corev1alpha1.BuildpackInfo{
+									Id:      "org.cloudfoundry.nodejs",
+									Version: "1.2.3",
+								},
+								Optional: false,
+							},
+						},
+						{
+							BuildpackRef: corev1alpha1.BuildpackRef{
+								BuildpackInfo: corev1alpha1.BuildpackInfo{
+									Id:      "org.cloudfoundry.npm",
+									Version: "4.5.6",
+								},
+								Optional: true,
+							},
+						},
+					},
+				},
+				{
+					Group: []buildv1alpha2.BuilderBuildpackRef{
+						{
+							BuildpackRef: corev1alpha1.BuildpackRef{
+								BuildpackInfo: corev1alpha1.BuildpackInfo{
+									Id:      "org.cloudfoundry.go",
+									Version: "",
+								},
+								Optional: false,
+							},
+						},
+					},
+				},
+			}
+
+			assert.Equal(t, expectedOrder, order)
+		})
+	})
+
+	when("the image does not contain the order label", func() {
+		it("returns an error", func() {
+			fakeImage := &fake.FakeImage{}
+			fakeImage.ConfigFileReturns(&v1.ConfigFile{
+				Config: v1.Config{
+					Labels: map[string]string{},
+				},
+			}, nil)
+
+			fakeFetcher.SetImage(imageRef, fakeImage)
+
+			_, err := builder.ReadOrderFromImage(keychain, fakeFetcher, imageRef)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "does not contain the io.buildpacks.buildpack.order label")
+		})
+	})
+
+	when("the order label contains invalid JSON", func() {
+		it("returns an error", func() {
+			fakeImage := &fake.FakeImage{}
+			fakeImage.ConfigFileReturns(&v1.ConfigFile{
+				Config: v1.Config{
+					Labels: map[string]string{
+						"io.buildpacks.buildpack.order": "not valid json",
+					},
+				},
+			}, nil)
+
+			fakeFetcher.SetImage(imageRef, fakeImage)
+
+			_, err := builder.ReadOrderFromImage(keychain, fakeFetcher, imageRef)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to parse io.buildpacks.buildpack.order label")
+		})
+	})
+
+	when("the image cannot be fetched", func() {
+		it("returns an error", func() {
+			fakeFetcher.SetError("some-error")
+
+			_, err := builder.ReadOrderFromImage(keychain, fakeFetcher, imageRef)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to fetch image")
+		})
+	})
+}

--- a/pkg/commands/builder/create_test.go
+++ b/pkg/commands/builder/create_test.go
@@ -401,7 +401,7 @@ status:
 							"--buildpack", "some-buildpack-name",
 						},
 						ExpectErr: true,
-						ExpectedErrorOutput: `Error: cannot use --order and --buildpack together
+						ExpectedErrorOutput: `Error: only one of --order, --buildpack, or --order-from can be specified
 `,
 					}.TestKpack(t, cmdFunc)
 				})

--- a/pkg/commands/builder/patch_test.go
+++ b/pkg/commands/builder/patch_test.go
@@ -189,7 +189,7 @@ func testPatchCommand(builderCommand func(clientSetProvider k8s.ClientSetProvide
 					"--buildpack", "org.cloudfoundry.test-bp",
 				},
 				ExpectErr:           true,
-				ExpectedErrorOutput: "Error: cannot use --order and --buildpack together\n",
+				ExpectedErrorOutput: "Error: only one of --order, --buildpack, or --order-from can be specified\n",
 			}.TestKpack(t, cmdFunc)
 		})
 

--- a/pkg/commands/clusterbuilder/create.go
+++ b/pkg/commands/clusterbuilder/create.go
@@ -16,7 +16,9 @@ import (
 	"github.com/buildpacks-community/kpack-cli/pkg/builder"
 	"github.com/buildpacks-community/kpack-cli/pkg/commands"
 	"github.com/buildpacks-community/kpack-cli/pkg/config"
+	"github.com/buildpacks-community/kpack-cli/pkg/dockercreds"
 	"github.com/buildpacks-community/kpack-cli/pkg/k8s"
+	"github.com/buildpacks-community/kpack-cli/pkg/registry"
 )
 
 const (
@@ -26,7 +28,8 @@ const (
 
 func NewCreateCommand(clientSetProvider k8s.ClientSetProvider, newWaiter func(dynamic.Interface) commands.ResourceWaiter) *cobra.Command {
 	var (
-		flags CommandFlags
+		flags     CommandFlags
+		tlsConfig registry.TLSConfig
 	)
 
 	cmd := &cobra.Command{
@@ -35,14 +38,15 @@ func NewCreateCommand(clientSetProvider k8s.ClientSetProvider, newWaiter func(dy
 		Long: `Create a cluster builder by providing command line arguments.
 The cluster builder will be created only if it does not exist.
 
-A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
-Multiple buildpacks provided via the --buildpack flag will be added to the same order group. 
+A buildpack order must be provided with either the path to an order yaml, via the --buildpack flag, or extracted from a builder image using --order-from.
+Multiple buildpacks provided via the --buildpack flag will be added to the same order group.
 
 Tag when not specified, defaults to a combination of the default repository and specified builder name.
 The default repository is read from the "default.repository" key in the "kp-config" ConfigMap within "kpack" namespace.
 `,
 		Example: `kp clusterbuilder create my-builder --order /path/to/order.yaml --stack tiny --store my-store
 kp clusterbuilder create my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1
+kp clusterbuilder create my-builder --order-from paketobuildpacks/builder-jammy-base --stack tiny --store my-store
 kp clusterbuilder create my-builder --tag my-registry.com/my-builder-tag --order /path/to/order.yaml --stack tiny --store my-store
 kp clusterbuilder create my-builder --tag my-registry.com/my-builder-tag --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
@@ -61,7 +65,8 @@ kp clusterbuilder create my-builder --tag my-registry.com/my-builder-tag --build
 			name := args[0]
 			ctx := cmd.Context()
 
-			return create(ctx, name, flags, ch, cs, newWaiter(cs.DynamicClient))
+			fetcher := registry.NewDefaultFetcher(tlsConfig)
+			return create(ctx, name, flags, ch, cs, fetcher, newWaiter(cs.DynamicClient))
 		},
 	}
 
@@ -70,7 +75,9 @@ kp clusterbuilder create my-builder --tag my-registry.com/my-builder-tag --build
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
 	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
+	cmd.Flags().StringVar(&flags.orderFrom, "order-from", "", "builder image to extract buildpack order from")
 	commands.SetDryRunOutputFlags(cmd)
+	commands.SetTLSFlags(cmd, &tlsConfig)
 	return cmd
 }
 
@@ -80,9 +87,10 @@ type CommandFlags struct {
 	store      string
 	order      string
 	buildpacks []string
+	orderFrom  string
 }
 
-func create(ctx context.Context, name string, flags CommandFlags, ch *commands.CommandHelper, cs k8s.ClientSet, waiter commands.ResourceWaiter) error {
+func create(ctx context.Context, name string, flags CommandFlags, ch *commands.CommandHelper, cs k8s.ClientSet, fetcher builder.Fetcher, waiter commands.ResourceWaiter) error {
 	kpConfig := config.NewKpConfigProvider(cs.K8sClient).GetKpConfig(ctx)
 
 	if flags.tag == "" {
@@ -115,26 +123,42 @@ func create(ctx context.Context, name string, flags CommandFlags, ch *commands.C
 		},
 	}
 
-	if len(flags.buildpacks) > 0 && flags.order != "" {
-		return fmt.Errorf("cannot use --order and --buildpack together")
+	// Validate that only one order source is provided
+	orderSourceCount := 0
+	if len(flags.buildpacks) > 0 {
+		orderSourceCount++
+	}
+	if flags.order != "" {
+		orderSourceCount++
+	}
+	if flags.orderFrom != "" {
+		orderSourceCount++
+	}
+	if orderSourceCount > 1 {
+		return fmt.Errorf("only one of --order, --buildpack, or --order-from can be specified")
 	}
 
+	// Set the order based on the provided flag
+	var err error
 	if len(flags.buildpacks) > 0 {
 		cb.Spec.Order = builder.CreateOrder(flags.buildpacks)
+	} else if flags.order != "" {
+		cb.Spec.Order, err = builder.ReadOrder(flags.order)
+		if err != nil {
+			return err
+		}
+	} else if flags.orderFrom != "" {
+		keychain := dockercreds.DefaultKeychain
+		cb.Spec.Order, err = builder.ReadOrderFromImage(keychain, fetcher, flags.orderFrom)
+		if err != nil {
+			return err
+		}
 	}
 
 	if flags.store != "" {
 		cb.Spec.Store = corev1.ObjectReference{
 			Name: flags.store,
 			Kind: v1alpha2.ClusterStoreKind,
-		}
-	}
-
-	var err error
-	if flags.order != "" {
-		cb.Spec.Order, err = builder.ReadOrder(flags.order)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/pkg/commands/clusterbuilder/create_test.go
+++ b/pkg/commands/clusterbuilder/create_test.go
@@ -446,7 +446,7 @@ status:
 							"--buildpack", "some-buildpack-name",
 						},
 						ExpectErr:           true,
-						ExpectedErrorOutput: "Error: cannot use --order and --buildpack together\n",
+						ExpectedErrorOutput: "Error: only one of --order, --buildpack, or --order-from can be specified\n",
 					}.TestK8sAndKpack(t, cmdFunc)
 				})
 			})

--- a/pkg/commands/clusterbuilder/patch.go
+++ b/pkg/commands/clusterbuilder/patch.go
@@ -16,12 +16,15 @@ import (
 
 	"github.com/buildpacks-community/kpack-cli/pkg/builder"
 	"github.com/buildpacks-community/kpack-cli/pkg/commands"
+	"github.com/buildpacks-community/kpack-cli/pkg/dockercreds"
 	"github.com/buildpacks-community/kpack-cli/pkg/k8s"
+	"github.com/buildpacks-community/kpack-cli/pkg/registry"
 )
 
 func NewPatchCommand(clientSetProvider k8s.ClientSetProvider, newWaiter func(dynamic.Interface) commands.ResourceWaiter) *cobra.Command {
 	var (
-		flags CommandFlags
+		flags     CommandFlags
+		tlsConfig registry.TLSConfig
 	)
 
 	cmd := &cobra.Command{
@@ -29,10 +32,11 @@ func NewPatchCommand(clientSetProvider k8s.ClientSetProvider, newWaiter func(dyn
 		Short: "Patch an existing cluster builder configuration",
 		Long: `Patch an existing clusterbuilder configuration by providing command line arguments.
 
-A buildpack order must be provided with either the path to an order yaml or via the --buildpack flag.
+A buildpack order must be provided with either the path to an order yaml, via the --buildpack flag, or extracted from a builder image using --order-from.
 Multiple buildpacks provided via the --buildpack flag will be added to the same order group.`,
 		Example: `kp clusterbuilder patch my-builder --order /path/to/order.yaml --stack tiny --store my-store
 kp clusterbuilder patch my-builder --order /path/to/order.yaml
+kp clusterbuilder patch my-builder --order-from paketobuildpacks/builder-jammy-base
 kp clusterbuilder patch my-builder --buildpack my-buildpack-id --buildpack my-other-buildpack@1.0.1`,
 		Args:         commands.ExactArgsWithUsage(1),
 		SilenceUsage: true,
@@ -55,7 +59,8 @@ kp clusterbuilder patch my-builder --buildpack my-buildpack-id --buildpack my-ot
 				return err
 			}
 
-			return patch(ctx, cb, flags, ch, cs, newWaiter(cs.DynamicClient))
+			fetcher := registry.NewDefaultFetcher(tlsConfig)
+			return patch(ctx, cb, flags, ch, cs, fetcher, newWaiter(cs.DynamicClient))
 		},
 	}
 
@@ -64,11 +69,13 @@ kp clusterbuilder patch my-builder --buildpack my-buildpack-id --buildpack my-ot
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
 	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
+	cmd.Flags().StringVar(&flags.orderFrom, "order-from", "", "builder image to extract buildpack order from")
 	commands.SetDryRunOutputFlags(cmd)
+	commands.SetTLSFlags(cmd, &tlsConfig)
 	return cmd
 }
 
-func patch(ctx context.Context, cb *v1alpha2.ClusterBuilder, flags CommandFlags, ch *commands.CommandHelper, cs k8s.ClientSet, waiter commands.ResourceWaiter) error {
+func patch(ctx context.Context, cb *v1alpha2.ClusterBuilder, flags CommandFlags, ch *commands.CommandHelper, cs k8s.ClientSet, fetcher builder.Fetcher, waiter commands.ResourceWaiter) error {
 	updatedCb := cb.DeepCopy()
 
 	if flags.tag != "" {
@@ -83,10 +90,23 @@ func patch(ctx context.Context, cb *v1alpha2.ClusterBuilder, flags CommandFlags,
 		updatedCb.Spec.Store.Name = flags.store
 	}
 
-	if len(flags.buildpacks) > 0 && flags.order != "" {
-		return fmt.Errorf("cannot use --order and --buildpack together")
+	// Validate that only one order source is provided
+	orderSourceCount := 0
+	if len(flags.buildpacks) > 0 {
+		orderSourceCount++
+	}
+	if flags.order != "" {
+		orderSourceCount++
+	}
+	if flags.orderFrom != "" {
+		orderSourceCount++
+	}
+	if orderSourceCount > 1 {
+		return fmt.Errorf("only one of --order, --buildpack, or --order-from can be specified")
 	}
 
+	// Set the order based on the provided flag
+	var err error
 	if flags.order != "" {
 		orderEntries, err := builder.ReadOrder(flags.order)
 		if err != nil {
@@ -94,10 +114,14 @@ func patch(ctx context.Context, cb *v1alpha2.ClusterBuilder, flags CommandFlags,
 		}
 
 		updatedCb.Spec.Order = orderEntries
-	}
-
-	if len(flags.buildpacks) > 0 {
+	} else if len(flags.buildpacks) > 0 {
 		updatedCb.Spec.Order = builder.CreateOrder(flags.buildpacks)
+	} else if flags.orderFrom != "" {
+		keychain := dockercreds.DefaultKeychain
+		updatedCb.Spec.Order, err = builder.ReadOrderFromImage(keychain, fetcher, flags.orderFrom)
+		if err != nil {
+			return err
+		}
 	}
 
 	patch, err := k8s.CreatePatch(cb, updatedCb)

--- a/pkg/commands/clusterbuilder/patch_test.go
+++ b/pkg/commands/clusterbuilder/patch_test.go
@@ -177,7 +177,7 @@ func testPatchCommand(clusterBuilderCommand func(clientSetProvider k8s.ClientSet
 					"--buildpack", "org.cloudfoundry.test-bp",
 				},
 				ExpectErr:           true,
-				ExpectedErrorOutput: "Error: cannot use --order and --buildpack together\n",
+				ExpectedErrorOutput: "Error: only one of --order, --buildpack, or --order-from can be specified\n",
 			}.TestKpack(t, cmdFunc)
 		})
 

--- a/pkg/commands/clusterbuilder/save.go
+++ b/pkg/commands/clusterbuilder/save.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/buildpacks-community/kpack-cli/pkg/commands"
 	"github.com/buildpacks-community/kpack-cli/pkg/k8s"
+	"github.com/buildpacks-community/kpack-cli/pkg/registry"
 )
 
 func NewSaveCommand(clientSetProvider k8s.ClientSetProvider, newWaiter func(dynamic.Interface) commands.ResourceWaiter) *cobra.Command {
 	var (
-		flags CommandFlags
+		flags     CommandFlags
+		tlsConfig registry.TLSConfig
 	)
 
 	cmd := &cobra.Command{
@@ -59,12 +61,14 @@ kp clusterbuilder save my-builder --tag my-registry.com/my-builder-tag --buildpa
 					flags.stack = defaultStack
 				}
 
-				return create(ctx, name, flags, ch, cs, w)
+				fetcher := registry.NewDefaultFetcher(tlsConfig)
+				return create(ctx, name, flags, ch, cs, fetcher, w)
 			} else if err != nil {
 				return err
 			}
 
-			return patch(ctx, cb, flags, ch, cs, w)
+			fetcher := registry.NewDefaultFetcher(tlsConfig)
+			return patch(ctx, cb, flags, ch, cs, fetcher, w)
 		},
 	}
 
@@ -73,6 +77,8 @@ kp clusterbuilder save my-builder --tag my-registry.com/my-builder-tag --buildpa
 	cmd.Flags().StringVar(&flags.store, "store", "", "buildpack store to use")
 	cmd.Flags().StringVarP(&flags.order, "order", "o", "", "path to buildpack order yaml")
 	cmd.Flags().StringSliceVarP(&flags.buildpacks, "buildpack", "b", []string{}, "buildpack id and optional version in the form of either '<buildpack>@<version>' or '<buildpack>'\n  repeat for each buildpack in order, or supply once with comma-separated list")
+	cmd.Flags().StringVar(&flags.orderFrom, "order-from", "", "builder image to extract buildpack order from")
 	commands.SetDryRunOutputFlags(cmd)
+	commands.SetTLSFlags(cmd, &tlsConfig)
 	return cmd
 }

--- a/pkg/testhelpers/fake_fetcher.go
+++ b/pkg/testhelpers/fake_fetcher.go
@@ -1,0 +1,46 @@
+// Copyright 2020-Present VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package testhelpers
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type FakeFetcher struct {
+	images map[string]v1.Image
+	err    string
+}
+
+func NewFakeFetcher() *FakeFetcher {
+	return &FakeFetcher{
+		images: make(map[string]v1.Image),
+	}
+}
+
+func (f *FakeFetcher) SetImage(imageRef string, image v1.Image) {
+	if f.images == nil {
+		f.images = make(map[string]v1.Image)
+	}
+	f.images[imageRef] = image
+}
+
+func (f *FakeFetcher) SetError(err string) {
+	f.err = err
+}
+
+func (f *FakeFetcher) Fetch(keychain authn.Keychain, src string) (v1.Image, error) {
+	if f.err != "" {
+		return nil, fmt.Errorf("%s", f.err)
+	}
+
+	img, ok := f.images[src]
+	if !ok {
+		return nil, fmt.Errorf("image not found: %s", src)
+	}
+
+	return img, nil
+}


### PR DESCRIPTION
This PR resolves the issue #384 : 
Flag to import buildpack order from existing CNB builder images when creating Builders/ClusterBuilders 