### PR TITLE
Remove references to DefaultClusterBuildpack 

### DIFF
--- a/pkg/commands/clusterbuildpack/status_test.go
+++ b/pkg/commands/clusterbuildpack/status_test.go
@@ -42,7 +42,7 @@ Reason:    this buildpack is not ready for the purpose of a test
 	)
 
 	var (
-		readyDefaultClusterBuildpack = &buildv1alpha2.ClusterBuildpack{
+		readyClusterBuildpack = &buildv1alpha2.ClusterBuildpack{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       buildv1alpha2.ClusterBuildpackKind,
 				APIVersion: "kpack.io/v1alpha2",
@@ -78,7 +78,7 @@ Reason:    this buildpack is not ready for the purpose of a test
 				},
 			},
 		}
-		notReadyDefaultClusterBuildpack = &buildv1alpha2.ClusterBuildpack{
+		notReadyClusterBuildpack = &buildv1alpha2.ClusterBuildpack{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       buildv1alpha2.ClusterBuildpackKind,
 				APIVersion: "kpack.io/v1alpha2",
@@ -107,7 +107,7 @@ Reason:    this buildpack is not ready for the purpose of a test
 				},
 			},
 		}
-		unknownDefaultClusterBuildpack = &buildv1alpha2.ClusterBuildpack{
+		unknownClusterBuildpack = &buildv1alpha2.ClusterBuildpack{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       buildv1alpha2.ClusterBuildpackKind,
 				APIVersion: "kpack.io/v1alpha2",
@@ -138,7 +138,7 @@ Reason:    this buildpack is not ready for the purpose of a test
 			when("the buildpack is ready", func() {
 				it("shows the build status using status.order", func() {
 					testhelpers.CommandTest{
-						Objects:        []runtime.Object{readyDefaultClusterBuildpack},
+						Objects:        []runtime.Object{readyClusterBuildpack},
 						Args:           []string{"test-buildpack-1"},
 						ExpectedOutput: expectedReadyOutput,
 					}.TestKpack(t, cmdFunc)
@@ -148,7 +148,7 @@ Reason:    this buildpack is not ready for the purpose of a test
 			when("the buildpack is not ready", func() {
 				it("shows the build status of not ready buildpack", func() {
 					testhelpers.CommandTest{
-						Objects:        []runtime.Object{notReadyDefaultClusterBuildpack},
+						Objects:        []runtime.Object{notReadyClusterBuildpack},
 						Args:           []string{"test-buildpack-2"},
 						ExpectedOutput: expectedNotReadyOutput,
 					}.TestKpack(t, cmdFunc)
@@ -158,7 +158,7 @@ Reason:    this buildpack is not ready for the purpose of a test
 			when("the buildpack is unknown", func() {
 				it("shows the build status of unknown buildpack", func() {
 					testhelpers.CommandTest{
-						Objects:        []runtime.Object{unknownDefaultClusterBuildpack},
+						Objects:        []runtime.Object{unknownClusterBuildpack},
 						Args:           []string{"test-buildpack-3"},
 						ExpectedOutput: expectedUnkownOutput,
 					}.TestKpack(t, cmdFunc)

--- a/pkg/import/dependency_descriptor.go
+++ b/pkg/import/dependency_descriptor.go
@@ -100,9 +100,6 @@ func ValidateDescriptor(d DependencyDescriptor) error {
 		return errors.Errorf("default cluster lifecycle '%s' not found", d.DefaultClusterLifecycle)
 	}
 
-	if _, ok := buildpackSet[d.DefaultClusterBuildpack]; !ok && d.DefaultClusterBuildpack != "" {
-		return errors.Errorf("default cluster buildpack '%s' not found", d.DefaultClusterBuildpack)
-	}
 
 	if _, ok := stackSet[d.DefaultClusterStack]; !ok && d.DefaultClusterStack != "" {
 		return errors.Errorf("default cluster stack '%s' not found", d.DefaultClusterStack)
@@ -138,17 +135,7 @@ func GetClusterLifecycles(d DependencyDescriptor) []ClusterLifecycle {
 }
 
 func GetClusterBuildpacks(d DependencyDescriptor) []ClusterBuildpack {
-	buildpacks := d.ClusterBuildpacks
-	for _, bp := range d.ClusterBuildpacks {
-		if bp.Name == d.DefaultClusterBuildpack {
-			buildpacks = append(buildpacks, ClusterBuildpack{
-				Name:  "default",
-				Image: bp.Image,
-			})
-			break
-		}
-	}
-	return buildpacks
+	return d.ClusterBuildpacks
 }
 
 func GetClusterStores(d DependencyDescriptor) []ClusterStore {

--- a/pkg/import/dependency_descriptor_test.go
+++ b/pkg/import/dependency_descriptor_test.go
@@ -307,39 +307,21 @@ func testDescriptor(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#GetClusterBuildpacks", func() {
-		when("there is a default buildpack", func() {
-			it("returns the cluster buildpacks and the default cluster buildpack", func() {
-				descWithDefault := importpkg.DependencyDescriptor{
-					DefaultClusterBuildpack: "some-buildpack",
-					ClusterBuildpacks: []importpkg.ClusterBuildpack{
-						{Name: "some-buildpack", Image: "buildpack-image"},
-						{Name: "other-buildpack", Image: "other-image"},
-					},
-				}
-				buildpacks := importpkg.GetClusterBuildpacks(descWithDefault)
-				expectedBuildpacks := []importpkg.ClusterBuildpack{
+		it("returns the cluster buildpacks", func() {
+			descWithDefault := importpkg.DependencyDescriptor{
+				ClusterBuildpacks: []importpkg.ClusterBuildpack{
 					{Name: "some-buildpack", Image: "buildpack-image"},
 					{Name: "other-buildpack", Image: "other-image"},
-					{Name: "default", Image: "buildpack-image"},
-				}
-				require.Equal(t, expectedBuildpacks, buildpacks)
-			})
+				},
+			}
+			buildpacks := importpkg.GetClusterBuildpacks(descWithDefault)
+			expectedBuildpacks := []importpkg.ClusterBuildpack{
+				{Name: "some-buildpack", Image: "buildpack-image"},
+				{Name: "other-buildpack", Image: "other-image"},
+			}
+			require.Equal(t, expectedBuildpacks, buildpacks)
 		})
 
-		when("there is no default buildpack", func() {
-			it("returns only the cluster buildpacks", func() {
-				descWithoutDefault := importpkg.DependencyDescriptor{
-					ClusterBuildpacks: []importpkg.ClusterBuildpack{
-						{Name: "some-buildpack", Image: "buildpack-image"},
-					},
-				}
-				buildpacks := importpkg.GetClusterBuildpacks(descWithoutDefault)
-				expectedBuildpacks := []importpkg.ClusterBuildpack{
-					{Name: "some-buildpack", Image: "buildpack-image"},
-				}
-				require.Equal(t, expectedBuildpacks, buildpacks)
-			})
-		})
 	})
 
 	when("validating default lifecycle", func() {
@@ -362,33 +344,6 @@ func testDescriptor(t *testing.T, when spec.G, it spec.S) {
 				descWithoutDefault := importpkg.DependencyDescriptor{
 					ClusterLifecycles: []importpkg.ClusterLifecycle{
 						{Name: "some-lifecycle", Image: "lifecycle-image"},
-					},
-				}
-				require.NoError(t, importpkg.ValidateDescriptor(descWithoutDefault))
-			})
-		})
-	})
-
-	when("validating default buildpack", func() {
-		when("the default buildpack does not exist", func() {
-			it("fails validation", func() {
-				descWithBadDefault := importpkg.DependencyDescriptor{
-					DefaultClusterBuildpack: "does-not-exist",
-					ClusterBuildpacks: []importpkg.ClusterBuildpack{
-						{Name: "some-buildpack", Image: "buildpack-image"},
-					},
-				}
-				err := importpkg.ValidateDescriptor(descWithBadDefault)
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "default cluster buildpack 'does-not-exist' not found")
-			})
-		})
-
-		when("there is no default cluster buildpack", func() {
-			it("validates successfully", func() {
-				descWithoutDefault := importpkg.DependencyDescriptor{
-					ClusterBuildpacks: []importpkg.ClusterBuildpack{
-						{Name: "some-buildpack", Image: "buildpack-image"},
 					},
 				}
 				require.NoError(t, importpkg.ValidateDescriptor(descWithoutDefault))

--- a/pkg/import/descriptor/v1.go
+++ b/pkg/import/descriptor/v1.go
@@ -22,7 +22,6 @@ type DependencyDescriptor struct {
 	APIVersion              string             `yaml:"apiVersion" json:"apiVersion"`
 	Kind                    string             `yaml:"kind" json:"kind"`
 	DefaultClusterLifecycle string             `yaml:"defaultClusterLifecycle,omitempty" json:"defaultClusterLifecycle,omitempty"`
-	DefaultClusterBuildpack string             `yaml:"defaultClusterBuildpack,omitempty" json:"defaultClusterBuildpack,omitempty"`
 	DefaultClusterStack     string             `yaml:"defaultClusterStack,omitempty" json:"defaultClusterStack,omitempty"`
 	DefaultClusterBuilder   string             `yaml:"defaultClusterBuilder,omitempty" json:"defaultClusterBuilder,omitempty"`
 	ClusterLifecycles       []ClusterLifecycle `yaml:"clusterLifecycles,omitempty" json:"clusterLifecycles,omitempty"`


### PR DESCRIPTION
I missed this during the review of the pr to add the new descriptor version, but it doesn't make sense to have.

I guess this is technically a breaking change so we could add the key back to the descriptor and just ever use it, but I also think it's highly unlikely anyone used it 
